### PR TITLE
⚡ Bolt: parallelize data fetching on ShopPage using Promise.all

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - [Promise.all Data Fetching Parallelization]
+**Learning:** Found a common Next.js pattern where independent server-side data fetching (e.g. `getDictionary`, `prisma.category.findMany`, and `prisma.product.findMany`) are chained sequentially using `await`, leading to a slower Time to First Byte (TTFB).
+**Action:** Always scan server components for consecutive `await` statements that don't depend on each other's results, and wrap them in a `Promise.all` block to execute them concurrently and improve performance.

--- a/src/app/[lang]/(shop)/shop/page.tsx
+++ b/src/app/[lang]/(shop)/shop/page.tsx
@@ -18,14 +18,6 @@ export default async function ShopPage(
     const categoryQuery = searchParams.category;
     const currentCategorySlug = typeof categoryQuery === 'string' ? categoryQuery : null;
 
-    // Load dictionary based on the locale
-    const dict = await getDictionary(lang as Locale);
-
-    // Fetch all categories
-    const categories = await prisma.category.findMany({
-        orderBy: { nameEn: 'asc' },
-    });
-
     // Build the query for products based on the requested category
     // If we have a category slug, we find the corresponding category record 
     // depending on the active language slug
@@ -38,20 +30,28 @@ export default async function ShopPage(
         }
     }
 
-    const products = await prisma.product.findMany({
-        where: {
-            ...categoryFilter,
-            // To ensure we only load visible products,
-            // optionally you can filter by status. 
-            // e.g., OR: [{ statusEn: 'published' }, { statusFr: 'publié' }]
-        },
-        orderBy: {
-            createdAt: 'desc',
-        },
-        include: {
-            category: true, // we can include the category if we need its details later
-        }
-    });
+    // Execute data fetching and dictionary loading in parallel
+    // This optimization reduces TTFB by fetching independent data concurrently
+    const [dict, categories, products] = await Promise.all([
+        getDictionary(lang as Locale),
+        prisma.category.findMany({
+            orderBy: { nameEn: 'asc' },
+        }),
+        prisma.product.findMany({
+            where: {
+                ...categoryFilter,
+                // To ensure we only load visible products,
+                // optionally you can filter by status.
+                // e.g., OR: [{ statusEn: 'published' }, { statusFr: 'publié' }]
+            },
+            orderBy: {
+                createdAt: 'desc',
+            },
+            include: {
+                category: true, // we can include the category if we need its details later
+            }
+        })
+    ]);
 
     return (
         <main className="container mx-auto px-4 md:px-8 py-8">


### PR DESCRIPTION
💡 What: Refactored `ShopPage` (`src/app/[lang]/(shop)/shop/page.tsx`) to execute three independent async operations (`getDictionary`, `prisma.category.findMany`, and `prisma.product.findMany`) in parallel using `Promise.all`.

🎯 Why: Previously, these three operations were executed sequentially in a waterfall pattern, unnecessarily extending the Time to First Byte (TTFB). Since they are independent, they can run concurrently.

📊 Impact: Reduces server response time (TTFB) from the sum of the request times to the maximum of the individual request times. This will make the Shop Page feel notably faster.

🔬 Measurement: Verify by loading `/[lang]/shop` with the Network tab open and observing the TTFB metric.

---
*PR created automatically by Jules for task [10815637801011318123](https://jules.google.com/task/10815637801011318123) started by @gokaiorg*