### PR TITLE
🎨 Palette: Add context-aware ARIA labels to cart controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - Context-Aware Screen Reader Labels in Lists
+**Learning:** When using generic `sr-only` labels (like "Increase quantity" or "Remove item") within list items, screen reader users miss crucial context about *which* item they are modifying. Even when visual context implies the association, screen reader context is strictly linear.
+**Action:** Always extract the relevant identifier (e.g., the localized product name `itemName`) and inject it into `sr-only` labels and `aria-label`s for interactive list controls (e.g., "Remove {itemName}").

--- a/src/components/cart/CartSheet.tsx
+++ b/src/components/cart/CartSheet.tsx
@@ -78,12 +78,14 @@ export function CartSheet() {
                                     ? item.images[0]
                                     : "https://images.unsplash.com/photo-1595246140625-573b715d11dc?q=80&w=2670&auto=format&fit=crop";
 
+                                const itemName = lang === "fr" ? item.nameFr : item.nameEn;
+
                                 return (
                                     <div key={item.id} className="flex items-center gap-4">
                                         <div className="relative h-16 w-16 overflow-hidden rounded-md border bg-muted">
                                             <Image
                                                 src={imageUrl}
-                                                alt={item.nameEn}
+                                                alt={itemName}
                                                 fill
                                                 className="object-cover"
                                                 sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -93,7 +95,7 @@ export function CartSheet() {
                                             <div className="flex items-start justify-between gap-4">
                                                 <div className="flex flex-col gap-1">
                                                     <h3 className="line-clamp-1 font-medium">
-                                                        {lang === "fr" ? item.nameFr : item.nameEn}
+                                                        {itemName}
                                                     </h3>
                                                     <p className="text-sm text-muted-foreground">${item.price.toFixed(2)}</p>
                                                 </div>
@@ -104,7 +106,7 @@ export function CartSheet() {
                                                     onClick={() => removeItem(item.id)}
                                                 >
                                                     <Trash2 className="h-4 w-4" />
-                                                    <span className="sr-only">Remove item</span>
+                                                    <span className="sr-only">Remove {itemName}</span>
                                                 </Button>
                                             </div>
 
@@ -118,9 +120,10 @@ export function CartSheet() {
                                                         disabled={isLoading}
                                                     >
                                                         <Minus className="h-3 w-3" />
+                                                        <span className="sr-only">Decrease quantity of {itemName}</span>
                                                     </Button>
-                                                    <div className="flex h-8 w-8 items-center justify-center text-sm">
-                                                        {item.quantity}
+                                                    <div className="flex h-8 w-8 items-center justify-center text-sm" aria-live="polite">
+                                                        <span className="sr-only">Quantity:</span> {item.quantity}
                                                     </div>
                                                     <Button
                                                         variant="ghost"
@@ -130,6 +133,7 @@ export function CartSheet() {
                                                         disabled={isLoading}
                                                     >
                                                         <Plus className="h-3 w-3" />
+                                                        <span className="sr-only">Increase quantity of {itemName}</span>
                                                     </Button>
                                                 </div>
                                             </div>


### PR DESCRIPTION
💡 **What:**
Added context-aware `sr-only` labels to the icon-only buttons (Remove, Decrease, Increase) in the shopping cart (`CartSheet.tsx`) and added `aria-live="polite"` to the quantity display. Also updated the product image `alt` text to use the localized product name.

🎯 **Why:**
Screen reader users navigating through a list of items previously only heard generic labels like "Increase quantity" or "Remove item". Without additional context, it's difficult to know *which* item they are modifying, as screen reader context is linear. Injecting the localized item name into the `sr-only` text fixes this. 

📸 **Before/After:**
*(Visuals remain unchanged. Screen readers now read out "Remove [Product Name]", "Decrease quantity of [Product Name]", etc., instead of just "Remove item" and empty strings for + and -)*

♿ **Accessibility:**
- Added localized product name context to "Remove item", "Decrease quantity", and "Increase quantity" buttons for screen readers.
- Added `aria-live="polite"` to the quantity count so screen readers automatically announce quantity updates when users click +/-.
- Updated image `alt` text to display the correct localized product name.

---
*PR created automatically by Jules for task [8232662033928426827](https://jules.google.com/task/8232662033928426827) started by @gokaiorg*