### PR TITLE
🎨 Palette: Add screen-reader-only text to icon buttons in CartSheet

### DIFF
--- a/src/components/cart/CartSheet.tsx
+++ b/src/components/cart/CartSheet.tsx
@@ -118,6 +118,7 @@ export function CartSheet() {
                                                         disabled={isLoading}
                                                     >
                                                         <Minus className="h-3 w-3" />
+                                                        <span className="sr-only">Decrease quantity</span>
                                                     </Button>
                                                     <div className="flex h-8 w-8 items-center justify-center text-sm">
                                                         {item.quantity}
@@ -130,6 +131,7 @@ export function CartSheet() {
                                                         disabled={isLoading}
                                                     >
                                                         <Plus className="h-3 w-3" />
+                                                        <span className="sr-only">Increase quantity</span>
                                                     </Button>
                                                 </div>
                                             </div>


### PR DESCRIPTION
💡 **What**: Added visually hidden `<span className="sr-only">` text to the icon-only "Decrease quantity" (Minus) and "Increase quantity" (Plus) buttons in the `CartSheet` component.
🎯 **Why**: Icon-only buttons lacking context or ARIA labels provide a poor experience for screen reader users, as the purpose of the control is unannounced.
📸 **Before/After**: Visually, the UI remains unchanged since `.sr-only` is exclusively for screen readers.
♿ **Accessibility**: Improves accessibility for screen readers by providing clear, context-aware descriptions for quantity control interactions.

---
*PR created automatically by Jules for task [14966367224549534210](https://jules.google.com/task/14966367224549534210) started by @gokaiorg*