### PR TITLE
🎨 Palette: [UX/a11y improvement] Add context-aware screen reader labels in cart

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-04 - Context-aware Screen Reader Labels in Cart
+**Learning:** In dynamically generated lists like shopping carts, generic `sr-only` labels ("Remove item", "Increase quantity") are unhelpful to screen reader users because they don't know *which* item is being targeted. Also, dynamic text components need their `alt` text and accessibility tags localized correctly.
+**Action:** Always extract the dynamically localized item name and use it to build context-aware `sr-only` descriptions (e.g., `Remove {itemName}`). Use this same variable for image `alt` attributes to ensure correct localization.

--- a/src/components/cart/CartSheet.tsx
+++ b/src/components/cart/CartSheet.tsx
@@ -78,12 +78,13 @@ export function CartSheet() {
                                     ? item.images[0]
                                     : "https://images.unsplash.com/photo-1595246140625-573b715d11dc?q=80&w=2670&auto=format&fit=crop";
 
+                                const itemName = lang === "fr" ? item.nameFr : item.nameEn;
                                 return (
                                     <div key={item.id} className="flex items-center gap-4">
                                         <div className="relative h-16 w-16 overflow-hidden rounded-md border bg-muted">
                                             <Image
                                                 src={imageUrl}
-                                                alt={item.nameEn}
+                                                alt={itemName}
                                                 fill
                                                 className="object-cover"
                                                 sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -93,7 +94,7 @@ export function CartSheet() {
                                             <div className="flex items-start justify-between gap-4">
                                                 <div className="flex flex-col gap-1">
                                                     <h3 className="line-clamp-1 font-medium">
-                                                        {lang === "fr" ? item.nameFr : item.nameEn}
+                                                        {itemName}
                                                     </h3>
                                                     <p className="text-sm text-muted-foreground">${item.price.toFixed(2)}</p>
                                                 </div>
@@ -104,7 +105,7 @@ export function CartSheet() {
                                                     onClick={() => removeItem(item.id)}
                                                 >
                                                     <Trash2 className="h-4 w-4" />
-                                                    <span className="sr-only">Remove item</span>
+                                                    <span className="sr-only">Remove {itemName}</span>
                                                 </Button>
                                             </div>
 
@@ -118,7 +119,7 @@ export function CartSheet() {
                                                         disabled={isLoading}
                                                     >
                                                         <Minus className="h-3 w-3" />
-                                                        <span className="sr-only">Decrease quantity</span>
+                                                        <span className="sr-only">Decrease quantity of {itemName}</span>
                                                     </Button>
                                                     <div className="flex h-8 w-8 items-center justify-center text-sm">
                                                         {item.quantity}
@@ -131,7 +132,7 @@ export function CartSheet() {
                                                         disabled={isLoading}
                                                     >
                                                         <Plus className="h-3 w-3" />
-                                                        <span className="sr-only">Increase quantity</span>
+                                                        <span className="sr-only">Increase quantity of {itemName}</span>
                                                     </Button>
                                                 </div>
                                             </div>


### PR DESCRIPTION
💡 What: Added context-aware screen reader text (e.g. "Remove [Item Name]") in the shopping cart and dynamically localized the image alt tags.
🎯 Why: Generic screen reader text ("Remove item", "Increase quantity") is ambiguous in a list. This allows screen reader users to know exactly which item's controls they are focusing on. Image `alt` tags were previously hard-coded to English, so this fixes proper localization.
📸 Before/After: Code change, no visual updates.
♿ Accessibility: Context-aware screen reader labels dramatically improve navigation in dynamic lists.

---
*PR created automatically by Jules for task [7458583820394786220](https://jules.google.com/task/7458583820394786220) started by @gokaiorg*