### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Pass-the-Hash vulnerability in auth fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Critical authorization bypass in `/admin` functionalities. Server Actions defined in `src/actions/admin.ts` (`createCategory`, `createProduct`, `seedDemoData`) lacked explicit authentication/authorization checks. Although the `/admin` routes are protected by `middleware.ts`, Server Actions can be invoked directly from anywhere, allowing unauthenticated users to modify the database.
 **Learning:** In Next.js App Router, `middleware.ts` protection on routes does not automatically secure Server Actions used by those routes. Server Actions are independent endpoints.
 **Prevention:** Every Server Action performing sensitive operations must include direct session validation (e.g., `const session = await auth(); if (session?.user?.role !== "ADMIN") return { error: "Unauthorized" };`) regardless of the route middleware.
+
+## 2024-05-25 - Pass-the-Hash Vulnerability in Plaintext Migration Fallback
+**Vulnerability:** A "Pass-the-Hash" vulnerability existed in the credentials authorization logic (`src/auth.ts`) used to migrate plaintext passwords to bcrypt. The fallback allowed login if `user.password === credentials.password`, meaning if an attacker obtained the bcrypt hash from the database, they could supply the hash string itself as their password.
+**Learning:** Fallback mechanisms intended for migration can be exploited if they don't explicitly exclude modernized/secure data formats (like bcrypt hashes).
+**Prevention:** Always scope down migration fallbacks. Ensure that a plaintext fallback condition explicitly checks that the stored value is not already a hashed value (e.g., `!user.password.startsWith('$2a$') && !user.password.startsWith('$2b$')`).

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -48,7 +48,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                         );
 
                         // Fallback for existing plaintext passwords (migration path)
-                        if (!isValidPassword && user.password === credentials.password) {
+                        // Make sure we don't allow "pass-the-hash" if the user's password is a bcrypt hash
+                        const isBcryptHash = user.password.startsWith('$2a$') || user.password.startsWith('$2b$');
+                        if (!isValidPassword && user.password === credentials.password && !isBcryptHash) {
                             isValidPassword = true;
                             // Hash the password for future logins
                             const hashedPassword = await bcrypt.hash(credentials.password as string, 10);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -49,7 +49,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
                         // Fallback for existing plaintext passwords (migration path)
                         // Make sure we don't allow "pass-the-hash" if the user's password is a bcrypt hash
-                        const isBcryptHash = user.password.startsWith('$2a$') || user.password.startsWith('$2b$');
+                        const isBcryptHash = user.password?.startsWith('$2a$') || user.password?.startsWith('$2b$') || user.password?.startsWith('$2y$') || user.password?.startsWith('$2x$');
                         if (!isValidPassword && user.password === credentials.password && !isBcryptHash) {
                             isValidPassword = true;
                             // Hash the password for future logins


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: A "Pass-the-Hash" vulnerability existed in the credentials authorization logic (`src/auth.ts`) that is used as a fallback for migrating plaintext passwords. Because it checked `user.password === credentials.password`, if an attacker compromised the database, they could log in by simply supplying a user's bcrypt hash string as the password, completely bypassing authentication.

🎯 **Impact**: An attacker who gained read access to the database (e.g. through SQL injection or backup leak) could log in to any account, since the bcrypt hash could be passed directly as the password and the fallback condition would succeed.

🔧 **Fix**: Updated the plaintext fallback logic to strictly check that the stored password is not a bcrypt hash (`!isBcryptHash`), verifying that it doesn't start with `$2a$` or `$2b$`.

✅ **Verification**: Code review confirms that the Pass-the-Hash bug is fixed without breaking the migration fallback logic for true plaintext passwords. I verified my changes via `pnpm lint` and `pnpm build`. Added a Sentinel journal entry documenting this finding.

---
*PR created automatically by Jules for task [2762894362607121](https://jules.google.com/task/2762894362607121) started by @gokaiorg*