### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Pass-the-Hash vulnerability in authentication fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Critical authorization bypass in `/admin` functionalities. Server Actions defined in `src/actions/admin.ts` (`createCategory`, `createProduct`, `seedDemoData`) lacked explicit authentication/authorization checks. Although the `/admin` routes are protected by `middleware.ts`, Server Actions can be invoked directly from anywhere, allowing unauthenticated users to modify the database.
 **Learning:** In Next.js App Router, `middleware.ts` protection on routes does not automatically secure Server Actions used by those routes. Server Actions are independent endpoints.
 **Prevention:** Every Server Action performing sensitive operations must include direct session validation (e.g., `const session = await auth(); if (session?.user?.role !== "ADMIN") return { error: "Unauthorized" };`) regardless of the route middleware.
+
+## 2024-05-25 - Pass-the-Hash Bypass in Authentication Migration
+**Vulnerability:** Critical Pass-the-Hash vulnerability in `/src/auth.ts`. The authentication fallback logic for migrating plaintext passwords allowed users to authenticate by supplying the stored bcrypt hash as their password input if they obtained it, effectively bypassing password checks.
+**Learning:** When implementing fallback authentication checks (like comparing `user.password === credentials.password` for older plaintext passwords), directly checking strings without ensuring the stored password is not already a hash creates a vulnerability where hashes act as passwords.
+**Prevention:** Always verify that a stored password string doesn't match the standard bcrypt format/prefixes (e.g., `$2a$`, `$2b$`, `$2y$`) before doing direct plaintext comparisons.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -48,7 +48,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                         );
 
                         // Fallback for existing plaintext passwords (migration path)
-                        if (!isValidPassword && user.password === credentials.password) {
+                        // Make sure the stored password is not already a hash to prevent Pass-the-Hash
+                        const isStoredHash = typeof user.password === 'string' && (user.password.startsWith("$2a$") || user.password.startsWith("$2b$") || user.password.startsWith("$2y$"));
+
+                        if (!isValidPassword && !isStoredHash && user.password === credentials.password) {
                             isValidPassword = true;
                             // Hash the password for future logins
                             const hashedPassword = await bcrypt.hash(credentials.password as string, 10);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The authentication fallback logic for migrating older plaintext passwords checked `user.password === credentials.password` directly, without verifying if the stored password was already a bcrypt hash. This allowed a critical "Pass-the-Hash" bypass, where a user could authenticate by supplying the raw bcrypt hash of their password if they were able to obtain it.
🎯 Impact: This vulnerability allows malicious users to bypass the authentication flow if they can obtain the stored bcrypt hash of any user's password.
🔧 Fix: We added a safety check `isStoredHash` which verifies if the stored `user.password` string starts with a standard bcrypt prefix (`$2a$`, `$2b$`, `$2y$`). The fallback logic will now reject authentication if the stored password is an existing hash, even if the provided `credentials.password` string strictly equals it. A `typeof` check was added as well to handle OAuth users correctly.
✅ Verification: Ensure the updated logic handles legacy strings and typical logins properly. Run `pnpm build` and `pnpm lint` to ensure no syntactical regressions were introduced.

---
*PR created automatically by Jules for task [757141853394404102](https://jules.google.com/task/757141853394404102) started by @gokaiorg*