### PR TITLE
🎨 Palette: [UX improvement] Add password visibility toggle and loading state to LoginForm

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -7,12 +7,14 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter }
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
     const router = useRouter();
     const params = useParams<{ lang: string }>();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [showPassword, setShowPassword] = useState(false);
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
 
@@ -83,17 +85,31 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     <div className="flex items-center">
                         <Label htmlFor="password">{dict.password}</Label>
                     </div>
-                    <Input
-                        id="password"
-                        type="password"
-                        required
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                    />
+                    <div className="relative">
+                        <Input
+                            id="password"
+                            type={showPassword ? "text" : "password"}
+                            required
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            className="pr-12"
+                        />
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground"
+                            onClick={() => setShowPassword((prev) => !prev)}
+                            aria-label={showPassword ? "Hide password" : "Show password"}
+                        >
+                            {showPassword ? "Hide" : "Show"}
+                        </Button>
+                    </div>
                 </div>
                 {error && <p className="text-sm text-destructive">{error}</p>}
                 <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? dict.login_btn_loading : dict.login_btn}
+                    {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    {loading ? (dict.login_btn_loading || "Loading...") : (dict.login_btn || "Sign in")}
                 </Button>
             </div>
         </form>


### PR DESCRIPTION
💡 **What:** 
Added a "Show/Hide" toggle to the password input field and integrated a loading spinner into the submit button within `src/components/LoginForm.tsx`.

🎯 **Why:** 
Users often mis-type their passwords and need a way to verify what they have entered, reducing friction during login. Additionally, providing immediate visual feedback (the loading spinner) when the form is submitted reassures the user that their request is being processed.

📸 **Before/After:** 
- Password field now has a toggle to swap between `text` and `password` types.
- The "Sign in" button switches to a `Loader2` spinning icon while `loading` is true.

♿ **Accessibility:** 
- The toggle button includes an `aria-label` that dynamically updates based on the current state ("Show password" / "Hide password") to support screen readers.
- Focus and active states on the new button use existing Radix/Tailwind semantic classes.

---
*PR created automatically by Jules for task [8539656889693275653](https://jules.google.com/task/8539656889693275653) started by @gokaiorg*