### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Pass-the-Hash Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Critical authorization bypass in `/admin` functionalities. Server Actions defined in `src/actions/admin.ts` (`createCategory`, `createProduct`, `seedDemoData`) lacked explicit authentication/authorization checks. Although the `/admin` routes are protected by `middleware.ts`, Server Actions can be invoked directly from anywhere, allowing unauthenticated users to modify the database.
 **Learning:** In Next.js App Router, `middleware.ts` protection on routes does not automatically secure Server Actions used by those routes. Server Actions are independent endpoints.
 **Prevention:** Every Server Action performing sensitive operations must include direct session validation (e.g., `const session = await auth(); if (session?.user?.role !== "ADMIN") return { error: "Unauthorized" };`) regardless of the route middleware.
+
+## 2024-05-18 - Pass-the-Hash in Password Migration Fallbacks
+**Vulnerability:** When implementing a fallback for migrating plaintext passwords (checking `user.password === credentials.password`), an attacker can pass the database's stored bcrypt hash as their plaintext password input to bypass authentication.
+**Learning:** This "Pass-the-Hash" vulnerability occurs when the fallback string match succeeds against the raw hash.
+**Prevention:** Always ensure type safety (`typeof user.password === 'string'`) and explicitly check that the stored string does not start with bcrypt prefixes (e.g., `!user.password.startsWith('$2a$')` and `!user.password.startsWith('$2b$')`) before doing direct string matching in legacy migration fallbacks.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -48,7 +48,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                         );
 
                         // Fallback for existing plaintext passwords (migration path)
-                        if (!isValidPassword && user.password === credentials.password) {
+                        // Explicitly check that the stored password is not already a bcrypt hash
+                        // to prevent Pass-the-Hash bypass vulnerabilities
+                        if (
+                            !isValidPassword &&
+                            typeof user.password === 'string' &&
+                            !user.password.startsWith('$2a$') &&
+                            !user.password.startsWith('$2b$') &&
+                            user.password === credentials.password
+                        ) {
                             isValidPassword = true;
                             // Hash the password for future logins
                             const hashedPassword = await bcrypt.hash(credentials.password as string, 10);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When authenticating users, the legacy plaintext password migration fallback did not explicitly check whether the stored password was already a bcrypt hash before allowing a direct string comparison. This could lead to a "Pass-the-Hash" vulnerability where an attacker could provide the raw database hash as their plaintext password input to bypass authentication.
🎯 Impact: High. An attacker with read access to the database hashes could authenticate as any user without needing to crack the hashes.
🔧 Fix: Added explicit checks in `src/auth.ts` to ensure that the stored password string does not begin with the `$2a$` or `$2b$` bcrypt prefixes before performing the fallback string comparison. Ensured type safety.
✅ Verification: Ran `pnpm build` and `pnpm lint` to verify that the app builds without errors. Reviewed `src/auth.ts` manually to confirm the explicit check prevents hash strings from being treated as plaintext fallbacks. Evaluated logic safely handles OAuth accounts with no password property.

---
*PR created automatically by Jules for task [10247942023242272065](https://jules.google.com/task/10247942023242272065) started by @gokaiorg*