### PR TITLE
🎨 Palette: Add context-aware ARIA label to Add to Cart button

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,30 @@
+
+> shop-template@0.1.0 dev /app
+> next dev
+
+▲ Next.js 16.1.6 (Turbopack)
+- Local:         http://localhost:3000
+- Network:       http://192.168.0.2:3000
+- Environments: .env
+
+✓ Starting...
+⚠ The "middleware" file convention is deprecated. Please use "proxy" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
+✓ Ready in 1732ms
+○ Compiling /[lang]/shop ...
+Firebase Admin environment variables are missing.
+Firebase Admin environment variables are missing.
+⨯ Error: Unable to detect a Project Id in the current environment.
+To learn more about authentication and Google APIs, visit:
+https://cloud.google.com/docs/authentication/getting-started
+    at <unknown> (https://cloud.google.com/docs/authentication/getting-started)
+    at ShopPage (src/app/[lang]/(shop)/shop/page.tsx:48:67)
+  46 |     const [dict, categoriesSnapshot] = await Promise.all([
+  47 |         getDictionary(lang as Locale),
+> 48 |         adminDb.collection('categories').orderBy('nameEn', 'asc').get()
+     |                                                                   ^
+  49 |     ]);
+  50 |
+  51 |     const categories = categoriesSnapshot.docs.map(doc =>  {
+  digest: '1908329866'
+}
+ GET /en/shop 500 in 8.9s (compile: 5.6s, proxy.ts: 153ms, render: 3.2s)

--- a/src/components/shop/ShopProductCard.tsx
+++ b/src/components/shop/ShopProductCard.tsx
@@ -59,6 +59,7 @@ export function ShopProductCard({ product, lang, dict }: ShopProductCardProps) {
                         size="sm"
                         className="rounded-full shadow-xs cursor-pointer"
                         onClick={handleAddToCart}
+                        aria-label={`${dict.add_to_cart || "Add to cart"} ${title}`}
                     >
                         {dict.add_to_cart || "Add to cart"}
                     </Button>


### PR DESCRIPTION
💡 What: Added a context-aware `aria-label` to the "Add to cart" button on the product cards.
🎯 Why: In a product grid, screen reader users navigating by interactive elements might hear repetitive "Add to cart" announcements without knowing which product the button is for. Adding the product title to the label solves this issue.
♿ Accessibility: Improves screen reader experience by making the "Add to cart" button announcement specific to the product (e.g. "Add to cart Premium Headphones" instead of just "Add to cart").

---
*PR created automatically by Jules for task [8449277187031739258](https://jules.google.com/task/8449277187031739258) started by @gokaiorg*