### PR TITLE
🎨 Palette: Add context-aware aria-label to cart button

### DIFF
--- a/src/components/shop/ShopProductCard.tsx
+++ b/src/components/shop/ShopProductCard.tsx
@@ -59,6 +59,7 @@ export function ShopProductCard({ product, lang, dict }: ShopProductCardProps) {
                         size="sm"
                         className="rounded-full shadow-xs cursor-pointer"
                         onClick={handleAddToCart}
+                        aria-label={`${dict.add_to_cart || "Add to cart"} ${title}`}
                     >
                         {dict.add_to_cart || "Add to cart"}
                     </Button>


### PR DESCRIPTION
**What**: Added a context-aware `aria-label` to the "Add to cart" button in `ShopProductCard.tsx`.
**Why**: When there are multiple products in a list, generic "Add to cart" buttons lack context for screen reader users. Including the product's title in the `aria-label` makes the action's target explicit.
**Accessibility**: Screen reader users will now hear "Add to cart [Product Name]" instead of just "Add to cart", improving clarity and confidence when interacting with the product catalog.

---
*PR created automatically by Jules for task [17867349936634118157](https://jules.google.com/task/17867349936634118157) started by @gokaiorg*