### PR TITLE
🎨 Palette: [UX improvement] Add context-aware aria-label to 'Add to cart' button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-04 - Context-aware Screen Reader Labels in Cart
 **Learning:** In dynamically generated lists like shopping carts, generic `sr-only` labels ("Remove item", "Increase quantity") are unhelpful to screen reader users because they don't know *which* item is being targeted. Also, dynamic text components need their `alt` text and accessibility tags localized correctly.
 **Action:** Always extract the dynamically localized item name and use it to build context-aware `sr-only` descriptions (e.g., `Remove {itemName}`). Use this same variable for image `alt` attributes to ensure correct localization. 
+## 2024-04-10 - Screen reader text context in list buttons
+**Learning:** Screen readers announce list actions out-of-context; adding item names to "Add to cart" buttons via aria-label drastically improves traversal without changing visual UI.
+**Action:** In all multi-item lists, append `title` or `name` into dynamic `aria-label` properties.

--- a/src/components/shop/ShopProductCard.tsx
+++ b/src/components/shop/ShopProductCard.tsx
@@ -18,9 +18,11 @@ export function ShopProductCard({ product, lang, dict }: ShopProductCardProps) {
     // const slug = lang === 'fr' ? product.slugFr : product.slugEn;
     const addItem = useCart(state => state.addItem);
 
+    const fallbackAddToCart = lang === 'fr' ? "Ajouter au panier" : "Add to cart";
+
     const handleAddToCart = () => {
         addItem(product);
-        toast.success(dict.added_to_cart || "Added to cart", {
+        toast.success(dict.added_to_cart || fallbackAddToCart, {
             description: title,
         });
     };
@@ -59,9 +61,9 @@ export function ShopProductCard({ product, lang, dict }: ShopProductCardProps) {
                         size="sm"
                         className="rounded-full shadow-xs cursor-pointer"
                         onClick={handleAddToCart}
-                        aria-label={`${dict.add_to_cart || "Add to cart"} ${title}`}
+                        aria-label={`${dict.add_to_cart || fallbackAddToCart} ${title}`}
                     >
-                        {dict.add_to_cart || "Add to cart"}
+                        {dict.add_to_cart || fallbackAddToCart}
                     </Button>
                 </div>
             </div>

--- a/src/components/shop/ShopProductCard.tsx
+++ b/src/components/shop/ShopProductCard.tsx
@@ -59,6 +59,7 @@ export function ShopProductCard({ product, lang, dict }: ShopProductCardProps) {
                         size="sm"
                         className="rounded-full shadow-xs cursor-pointer"
                         onClick={handleAddToCart}
+                        aria-label={`${dict.add_to_cart || "Add to cart"} ${title}`}
                     >
                         {dict.add_to_cart || "Add to cart"}
                     </Button>


### PR DESCRIPTION
- **💡 What:** Added a dynamic `aria-label` to the 'Add to cart' button in the `ShopProductCard` component that includes both the localized button text and the product title.
- **🎯 Why:** Users navigating with screen readers hear generic "Add to cart" buttons repeatedly in lists. This change makes it explicit *which* item is being added to the cart when traversing the page.
- **♿ Accessibility:** Improves WCAG Success Criterion 2.5.3 (Label in Name) by ensuring voice controls and screen readers have access to the exact item context within lists.

---
*PR created automatically by Jules for task [3693601686740613576](https://jules.google.com/task/3693601686740613576) started by @gokaiorg*