### PR TITLE
⚡ Bolt: Remove redundant isMounted from AccountToggle

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-04-04 - Remove unnecessary `isMounted` hydration checks to enable SSR
 **Learning:** Components like `ShopProductCard` often cargo-cult the `isMounted` hydration-safe pattern from components that actually need it (like a `CartSheet` that reads persisted local storage). If a component only *modifies* state (e.g., uses `addItem` from a Zustand store) or relies on stable server-provided props, the `isMounted` check forces it to render a skeleton on the server.
 **Action:** Remove `isMounted` hydration checks from components that do not render dynamic client-side state. This immediately enables full Server-Side Rendering (SSR) for those components, dramatically improving SEO, First Contentful Paint (FCP), and Largest Contentful Paint (LCP).
+
+## 2026-04-10 - Redundant Hydration Checks with useSession
+**Learning:** Components that rely on `next-auth/react`'s `useSession` do not need manual `isMounted` hydration checks because the hook natively exposes a `status` property that inherently tracks the loading state (`status === "loading"`). Adding `isMounted` creates unnecessary double-rendering and delays initial loading.
+**Action:** Rely exclusively on `status === "loading"` for loading skeletons rather than manual useEffect-based hydration flags in components with session state.

--- a/src/components/layout/AccountToggle.tsx
+++ b/src/components/layout/AccountToggle.tsx
@@ -18,13 +18,7 @@ import { AuthSheet } from "@/components/auth/AuthSheet"
 export function AccountToggle({ lang, dict }: { lang: string, dict: any }) {
     const { data: session, status } = useSession()
     
-    const [isMounted, setIsMounted] = React.useState(false);
-    
-    React.useEffect(() => {
-        setIsMounted(true);
-    }, []);
-
-    if (!isMounted || status === "loading") {
+    if (status === "loading") {
         return <div className="h-8 w-16 animate-pulse rounded-md bg-muted"></div>
     }
 


### PR DESCRIPTION
💡 What: Removed the redundant `isMounted` hydration check from the `AccountToggle` component.
🎯 Why: Components that rely on `next-auth/react`'s `useSession` do not need manual `isMounted` hydration checks because the hook natively exposes a `status` property that inherently tracks the loading state (`status === "loading"`). Adding `isMounted` creates an unnecessary state tracking and double-rendering on mount.
📊 Impact: Eliminates unnecessary skeleton rendering during hydration and allows Next.js to start Server-Side Rendering (SSR) the component immediately, dramatically improving SEO, First Contentful Paint (FCP), and Largest Contentful Paint (LCP).
🔬 Measurement: Verified that the `status === "loading"` property natively manages the skeleton, and building the application via `pnpm build` completes with no errors.

---
*PR created automatically by Jules for task [10417045158809984848](https://jules.google.com/task/10417045158809984848) started by @gokaiorg*