### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing input validation on checkout quantity

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Critical authorization bypass in `/admin` functionalities. Server Actions defined in `src/actions/admin.ts` (`createCategory`, `createProduct`, `seedDemoData`) lacked explicit authentication/authorization checks. Although the `/admin` routes are protected by `middleware.ts`, Server Actions can be invoked directly from anywhere, allowing unauthenticated users to modify the database.
 **Learning:** In Next.js App Router, `middleware.ts` protection on routes does not automatically secure Server Actions used by those routes. Server Actions are independent endpoints.
 **Prevention:** Every Server Action performing sensitive operations must include direct session validation (e.g., `const session = await auth(); if (session?.user?.role !== "ADMIN") return { error: "Unauthorized" };`) regardless of the route middleware.
+## 2024-05-24 - Input Validation in Checkout Action
+**Vulnerability:** Missing server-side validation for numerical inputs (specifically `quantity`) in `createCheckoutSession` within `src/actions/checkout.ts`.
+**Learning:** Client-side values can easily be manipulated. Trusting the client to provide positive integers for checkout item quantities can lead to application logic issues (like negative totals, or unexpected errors).
+**Prevention:** Always perform strict server-side type and bound validation (e.g., `Number.isInteger(quantity) && quantity > 0`) for numerical input provided by users before performing backend logic, especially in billing actions.

--- a/src/actions/checkout.ts
+++ b/src/actions/checkout.ts
@@ -9,6 +9,10 @@ export async function createCheckoutSession(items: any[], lang: string) {
         // Fetch source of truth for products to avoid trusting client-provided prices
         const verifiedItems = await Promise.all(
             items.map(async (item) => {
+                if (!Number.isInteger(item.quantity) || item.quantity <= 0) {
+                    throw new Error(`Invalid quantity for product: ${item.id}`);
+                }
+
                 const productDoc = await adminDb.collection("products").doc(item.id).get();
                 if (!productDoc.exists) {
                     throw new Error(`Product not found: ${item.id}`);

--- a/src/actions/checkout.ts
+++ b/src/actions/checkout.ts
@@ -9,8 +9,12 @@ export async function createCheckoutSession(items: any[], lang: string) {
         // Fetch source of truth for products to avoid trusting client-provided prices
         const verifiedItems = await Promise.all(
             items.map(async (item) => {
+                if (!item || !item.id) {
+                    throw new Error("Invalid item structure or missing product ID");
+                }
+
                 if (!Number.isInteger(item.quantity) || item.quantity <= 0) {
-                    throw new Error(`Invalid quantity for product: ${item.id}`);
+                    throw new Error(`Invalid quantity for product: ${item?.id}`);
                 }
 
                 const productDoc = await adminDb.collection("products").doc(item.id).get();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `createCheckoutSession` server action in `src/actions/checkout.ts` trusted the client-provided `item.quantity` without validating its type or ensuring it was a positive integer.
🎯 Impact: A malicious user could potentially pass negative, fractional, or non-numeric values for quantities during checkout, which could lead to application logic issues, integer underflow, or negative total amounts (if not caught by Stripe).
🔧 Fix: Added a strict server-side check using `Number.isInteger(item.quantity) && item.quantity > 0` before processing the checkout items.
✅ Verification: Ran `pnpm build` and `pnpm lint`. The action will now throw an error for invalid quantities cleanly before contacting the database or Stripe.

---
*PR created automatically by Jules for task [5727510094591728564](https://jules.google.com/task/5727510094591728564) started by @gokaiorg*