### PR TITLE
🛡️ Sentinel: [HIGH] Fix lack of server-side validation on checkout quantities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** A "Pass-the-Hash" vulnerability existed in the credentials authorization logic (`src/auth.ts`) used to migrate plaintext passwords to bcrypt. The fallback allowed login if `user.password === credentials.password`, meaning if an attacker obtained the bcrypt hash from the database, they could supply the hash string itself as their password.
 **Learning:** Fallback mechanisms intended for migration can be exploited if they don't explicitly exclude modernized/secure data formats (like bcrypt hashes).
 **Prevention:** Always scope down migration fallbacks. Ensure that a plaintext fallback condition explicitly checks that the stored value is not already a hashed value (e.g., `!user.password.startsWith('$2a$') && !user.password.startsWith('$2b$')`).
+## 2024-04-17 - Missing checkout quantity validation
+**Vulnerability:** The `createCheckoutSession` server action did not validate the client-provided `quantity` for checkout items. Since `quantity` is multiplied by `price` to determine the order total, a negative or fractional quantity from a malicious payload could lead to negative order totals, underflow, or bypassing proper pricing rules.
+**Learning:** Even when product *prices* are securely fetched from the backend (source of truth), any mathematical multipliers provided by the client (like `quantity`) must be strictly validated before calculation.
+**Prevention:** Always assert `Number.isInteger()` and `> 0` for any multiplier/quantity input originating from the client payload in sensitive calculations.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,4 +10,4 @@
 ## 2024-04-17 - Missing checkout quantity validation
 **Vulnerability:** The `createCheckoutSession` server action did not validate the client-provided `quantity` for checkout items. Since `quantity` is multiplied by `price` to determine the order total, a negative or fractional quantity from a malicious payload could lead to negative order totals, underflow, or bypassing proper pricing rules.
 **Learning:** Even when product *prices* are securely fetched from the backend (source of truth), any mathematical multipliers provided by the client (like `quantity`) must be strictly validated before calculation.
-**Prevention:** Always assert `Number.isInteger()` and `> 0` for any multiplier/quantity input originating from the client payload in sensitive calculations.
+**Prevention:** Always assert `Number.isSafeInteger()` and `> 0` for any multiplier/quantity input originating from the client payload in sensitive calculations.

--- a/src/actions/checkout.ts
+++ b/src/actions/checkout.ts
@@ -21,6 +21,10 @@ export async function createCheckoutSession(items: { id: string, quantity: numbe
         });
 
         const verifiedItems = items.map((item) => {
+            if (!Number.isInteger(item.quantity) || item.quantity <= 0) {
+                throw new Error(`Invalid quantity for item: ${item.id}`);
+            }
+
             const productDoc = productDocMap.get(item.id);
             if (!productDoc || !productDoc.exists) {
                 throw new Error(`Product not found: ${item.id}`);

--- a/src/actions/checkout.ts
+++ b/src/actions/checkout.ts
@@ -21,7 +21,11 @@ export async function createCheckoutSession(items: { id: string, quantity: numbe
         });
 
         const verifiedItems = items.map((item) => {
-            if (!Number.isInteger(item.quantity) || item.quantity <= 0) {
+            if (!item || typeof item !== 'object') {
+                throw new Error('Invalid item object');
+            }
+
+            if (!Number.isSafeInteger(item.quantity) || item.quantity <= 0) {
                 throw new Error(`Invalid quantity for item: ${item.id}`);
             }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `createCheckoutSession` Server Action did not validate the client-provided `quantity` for each checkout item.
🎯 Impact: A malicious client payload could supply a negative, zero, or floating-point number for the quantity, which would be multiplied by the verified price. This could lead to integer underflow, negative total order amounts, bypassing logic limits, and inventory manipulation.
🔧 Fix: Explicitly checked `!Number.isInteger(item.quantity) || item.quantity <= 0` and failed securely by throwing an error if the quantity is invalid.
✅ Verification: Ran `pnpm lint` and `pnpm build`, ensuring all checks passed without regression. Code has been verified manually as logically robust.

---
*PR created automatically by Jules for task [17171978553930977850](https://jules.google.com/task/17171978553930977850) started by @gokaiorg*