### PR TITLE
🎨 Palette: [UX improvement] Add active states to primary navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,10 @@
 ## 2024-04-04 - Context-aware Screen Reader Labels in Cart
 **Learning:** In dynamically generated lists like shopping carts, generic `sr-only` labels ("Remove item", "Increase quantity") are unhelpful to screen reader users because they don't know *which* item is being targeted. Also, dynamic text components need their `alt` text and accessibility tags localized correctly.
 **Action:** Always extract the dynamically localized item name and use it to build context-aware `sr-only` descriptions (e.g., `Remove {itemName}`). Use this same variable for image `alt` attributes to ensure correct localization. 
+## 2026-04-17 - Component Isolation for Playwright Testing
+**Learning:** When attempting to render components like  in Next.js using Playwright for visual testing, wrapping them in default layouts may trigger authentication or environment errors (like Firebase missing secrets). Creating an isolated test route (e.g., ) without global wrappers is an effective bypass to verify purely visual/UX changes.
+**Action:** Use isolated test routes for component-level visual verification when the full application environment is difficult to bootstrap in the test environment.
+
+## 2024-05-14 - Component Isolation for Playwright Testing
+**Learning:** When attempting to render components like `PrimaryNav` in Next.js using Playwright for visual testing, wrapping them in default layouts may trigger authentication or environment errors (like Firebase missing secrets). Creating an isolated test route (e.g., `src/app/[lang]/test-nav/page.tsx`) without global wrappers is an effective bypass to verify purely visual/UX changes.
+**Action:** Use isolated test routes for component-level visual verification when the full application environment is difficult to bootstrap in the test environment.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,10 +1,6 @@
 ## 2024-04-04 - Context-aware Screen Reader Labels in Cart
 **Learning:** In dynamically generated lists like shopping carts, generic `sr-only` labels ("Remove item", "Increase quantity") are unhelpful to screen reader users because they don't know *which* item is being targeted. Also, dynamic text components need their `alt` text and accessibility tags localized correctly.
 **Action:** Always extract the dynamically localized item name and use it to build context-aware `sr-only` descriptions (e.g., `Remove {itemName}`). Use this same variable for image `alt` attributes to ensure correct localization. 
-## 2026-04-17 - Component Isolation for Playwright Testing
-**Learning:** When attempting to render components like  in Next.js using Playwright for visual testing, wrapping them in default layouts may trigger authentication or environment errors (like Firebase missing secrets). Creating an isolated test route (e.g., ) without global wrappers is an effective bypass to verify purely visual/UX changes.
-**Action:** Use isolated test routes for component-level visual verification when the full application environment is difficult to bootstrap in the test environment.
-
 ## 2024-05-14 - Component Isolation for Playwright Testing
 **Learning:** When attempting to render components like `PrimaryNav` in Next.js using Playwright for visual testing, wrapping them in default layouts may trigger authentication or environment errors (like Firebase missing secrets). Creating an isolated test route (e.g., `src/app/[lang]/test-nav/page.tsx`) without global wrappers is an effective bypass to verify purely visual/UX changes.
 **Action:** Use isolated test routes for component-level visual verification when the full application environment is difficult to bootstrap in the test environment.

--- a/src/components/layout/PrimaryNav.tsx
+++ b/src/components/layout/PrimaryNav.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import React from "react";
+import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 interface PrimaryNavProps {
@@ -10,19 +13,32 @@ interface PrimaryNavProps {
 }
 
 export function PrimaryNav({ lang, dict, className, onNavClick }: PrimaryNavProps) {
+    const pathname = usePathname();
+
+    const isShopActive = pathname === `/${lang}/shop` || pathname.startsWith(`/${lang}/shop/`);
+    const isAboutActive = pathname === `/${lang}/about` || pathname.startsWith(`/${lang}/about/`);
+
     return (
         <nav className={cn("gap-6", className)}>
             <Link
                 href={`/${lang}/shop`}
                 onClick={onNavClick}
-                className="flex items-center text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                aria-current={isShopActive ? "page" : undefined}
+                className={cn(
+                    "flex items-center text-sm font-medium transition-colors hover:text-foreground",
+                    isShopActive ? "text-foreground" : "text-muted-foreground"
+                )}
             >
                 {dict.shop}
             </Link>
             <Link
                 href={`/${lang}/about`}
                 onClick={onNavClick}
-                className="flex items-center text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                aria-current={isAboutActive ? "page" : undefined}
+                className={cn(
+                    "flex items-center text-sm font-medium transition-colors hover:text-foreground",
+                    isAboutActive ? "text-foreground" : "text-muted-foreground"
+                )}
             >
                 {dict.about}
             </Link>

--- a/src/components/layout/PrimaryNav.tsx
+++ b/src/components/layout/PrimaryNav.tsx
@@ -15,8 +15,13 @@ interface PrimaryNavProps {
 export function PrimaryNav({ lang, dict, className, onNavClick }: PrimaryNavProps) {
     const pathname = usePathname();
 
-    const isShopActive = pathname === `/${lang}/shop` || pathname.startsWith(`/${lang}/shop/`);
-    const isAboutActive = pathname === `/${lang}/about` || pathname.startsWith(`/${lang}/about/`);
+    const isActive = (path: string) => {
+        if (!pathname) return false;
+        return pathname === path || pathname.startsWith(`${path}/`);
+    };
+
+    const isShopActive = isActive(`/${lang}/shop`);
+    const isAboutActive = isActive(`/${lang}/about`);
 
     return (
         <nav className={cn("gap-6", className)}>


### PR DESCRIPTION
## 🎨 Palette: Add Active States to Primary Navigation

**💡 What:** 
Added active state highlighting to the `PrimaryNav` component. The currently active page link now uses a brighter text color (`text-foreground`) compared to inactive links (`text-muted-foreground`).

**🎯 Why:**
Users need clear visual feedback to understand their current location within the application hierarchy. This is a fundamental UX pattern that reduces cognitive load and improves navigation clarity.

**♿ Accessibility:**
Added `aria-current="page"` to the active link to ensure screen readers properly announce the user's current location in the navigation menu, following WAI-ARIA best practices.

---
*PR created automatically by Jules for task [8625279089936656060](https://jules.google.com/task/8625279089936656060) started by @gokaiorg*