### PR TITLE
🎨 Palette: [UX improvement] Add autocomplete and loading state to LoginForm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 /src/generated/prisma
 shop-gcp-firebase-adminsdk-fbsvc-*.json
 
+dev_server.log

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-04 - Context-aware Screen Reader Labels in Cart
 **Learning:** In dynamically generated lists like shopping carts, generic `sr-only` labels ("Remove item", "Increase quantity") are unhelpful to screen reader users because they don't know *which* item is being targeted. Also, dynamic text components need their `alt` text and accessibility tags localized correctly.
 **Action:** Always extract the dynamically localized item name and use it to build context-aware `sr-only` descriptions (e.g., `Remove {itemName}`). Use this same variable for image `alt` attributes to ensure correct localization. 
+## 2024-04-18 - Auth Input Autofill
+**Learning:** Browser password managers and native autofill systems require semantic attributes beyond just `type="email"` or `type="password"` to function reliably. Omitting `name` and `autoComplete` attributes on custom input components causes a frustrating login UX where users must manually retype credentials.
+**Action:** Always include `id`, `name`, and explicit `autoComplete` attributes (e.g., `email`, `current-password`) when implementing or modifying authentication forms to ensure seamless password manager integration.

--- a/src/app/[lang]/(auth)/login/page.tsx
+++ b/src/app/[lang]/(auth)/login/page.tsx
@@ -32,7 +32,10 @@ export default function LoginPage() {
                     <div className="rounded-md shadow-sm -space-y-px">
                         <div>
                             <input
+                                id="email"
+                                name="email"
                                 type="email"
+                                autoComplete="email"
                                 required
                                 className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-black focus:border-black focus:z-10 sm:text-sm"
                                 placeholder="Email address"
@@ -42,7 +45,10 @@ export default function LoginPage() {
                         </div>
                         <div>
                             <input
+                                id="password"
+                                name="password"
                                 type="password"
+                                autoComplete="current-password"
                                 required
                                 className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-black focus:border-black focus:z-10 sm:text-sm"
                                 placeholder="Password"

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -17,6 +17,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
     const [showPassword, setShowPassword] = useState(false);
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
+    const [googleLoading, setGoogleLoading] = useState(false);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -51,11 +52,19 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     type="button"
                     variant="outline"
                     className="w-full"
-                    onClick={() => signIn("google", { callbackUrl: `/${params.lang || 'en'}/admin/dashboard` })}
+                    onClick={() => {
+                        setGoogleLoading(true);
+                        signIn("google", { callbackUrl: `/${params.lang || 'en'}/admin/dashboard` });
+                    }}
+                    disabled={googleLoading}
                 >
-                    <svg className="mr-2 h-4 w-4" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="google" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 488 512">
-                        <path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path>
-                    </svg>
+                    {googleLoading ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                        <svg className="mr-2 h-4 w-4" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="google" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 488 512">
+                            <path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path>
+                        </svg>
+                    )}
                     Sign in with Google
                 </Button>
 
@@ -74,7 +83,9 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     <Label htmlFor="email">{dict.email}</Label>
                     <Input
                         id="email"
+                        name="email"
                         type="email"
+                        autoComplete="email"
                         placeholder={dict.email_placeholder}
                         required
                         value={email}
@@ -88,7 +99,9 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     <div className="relative">
                         <Input
                             id="password"
+                            name="password"
                             type={showPassword ? "text" : "password"}
+                            autoComplete="current-password"
                             required
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -52,11 +52,15 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     type="button"
                     variant="outline"
                     className="w-full"
-                    onClick={() => {
+                    onClick={async () => {
                         setGoogleLoading(true);
-                        signIn("google", { callbackUrl: `/${params.lang || 'en'}/admin/dashboard` });
+                        try {
+                            await signIn("google", { callbackUrl: `/${params.lang || 'en'}/admin/dashboard` });
+                        } catch (error) {
+                            setGoogleLoading(false);
+                        }
                     }}
-                    disabled={googleLoading}
+                    disabled={googleLoading || loading}
                 >
                     {googleLoading ? (
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -65,7 +69,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                             <path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path>
                         </svg>
                     )}
-                    Sign in with Google
+                    {dict.google_sign_in || "Sign in with Google"}
                 </Button>
 
                 <div className="relative">


### PR DESCRIPTION
**💡 What:**
- Added standard `name` and `autoComplete` attributes (`email` and `current-password`) to the email and password inputs in `LoginForm.tsx` and `login/page.tsx`.
- Added a loading spinner (`Loader2`) and a disabled state to the "Sign in with Google" button during the asynchronous OAuth sign-in process.
- Ignored `dev_server.log` in `.gitignore`.

**🎯 Why:**
- To enable browser password managers and native autofill systems to seamlessly populate and update user credentials, saving users from manual entry.
- To prevent accidental double-clicks and provide immediate, clear visual feedback to the user that their sign-in request is processing.

**♿ Accessibility:**
- Improved form control semantics for password managers and assistive technologies by explicitly identifying the input fields' purpose.
- Provided explicit loading state and prevented interaction during background processes, reducing confusion for screen reader and keyboard users.

---
*PR created automatically by Jules for task [9462084612489977617](https://jules.google.com/task/9462084612489977617) started by @gokaiorg*