### PR TITLE
🎨 Palette: [UX improvement] Enhance password manager support in login form

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -74,7 +74,9 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     <Label htmlFor="email">{dict.email}</Label>
                     <Input
                         id="email"
+                        name="email"
                         type="email"
+                        autoComplete="email"
                         placeholder={dict.email_placeholder}
                         required
                         value={email}
@@ -88,7 +90,9 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                     <div className="relative">
                         <Input
                             id="password"
+                            name="password"
                             type={showPassword ? "text" : "password"}
+                            autoComplete="current-password"
                             required
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}


### PR DESCRIPTION
**💡 What:** 
Added proper HTML `name` and `autoComplete` attributes to the email and password input fields in the `LoginForm` component. 

**🎯 Why:**
This solves a key UX problem where password managers (like 1Password, Bitwarden, or browser built-in managers) fail to recognize the login form. Without explicit `name` and `autoComplete` attributes (like `autoComplete="email"` and `autoComplete="current-password"`), autofill often breaks or prompts fail to save updated credentials, causing a frustrating user experience.

**♿ Accessibility:**
This improves cognitive accessibility by allowing users to rely on their password managers, minimizing the memory load or manual typing required for logging in securely.

*(Verified locally via Playwright script to confirm attributes exist dynamically at runtime without affecting layout)*

---
*PR created automatically by Jules for task [320107563970772270](https://jules.google.com/task/320107563970772270) started by @gokaiorg*