### PR TITLE
⚡ Bolt: [performance improvement] Eliminate data fetching waterfall in ShopPage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-24 - Prevent N+1 queries in Firestore lookups
 **Learning:** Using `Promise.all(items.map(... => adminDb.collection("...").doc(id).get()))` creates an N+1 query problem, causing multiple network roundtrips to Firestore. This significantly degrades backend performance, especially when checking out carts with multiple items.
 **Action:** Always batch Firestore document lookups by ID into a single network call using `adminDb.getAll(...documentRefs)` instead of looping. Note that `getAll()` expects arguments to be spread and requires at least one document reference, so always add an empty array check (`if (items.length === 0) return/throw`).
+## 2024-03-21 - [Data Fetching Waterfalls in Next.js Server Components]
+**Learning:** Sequential await calls on un-started Promises block subsequent queries. In Next.js, `params` and `searchParams` are now asynchronous, and waiting for them before starting a database query creates a waterfall.
+**Action:** Start the database fetch Promise immediately (without `await`), then resolve it concurrently with the parameter Promises using `Promise.all()`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,6 +5,6 @@
 ## 2024-05-24 - Prevent N+1 queries in Firestore lookups
 **Learning:** Using `Promise.all(items.map(... => adminDb.collection("...").doc(id).get()))` creates an N+1 query problem, causing multiple network roundtrips to Firestore. This significantly degrades backend performance, especially when checking out carts with multiple items.
 **Action:** Always batch Firestore document lookups by ID into a single network call using `adminDb.getAll(...documentRefs)` instead of looping. Note that `getAll()` expects arguments to be spread and requires at least one document reference, so always add an empty array check (`if (items.length === 0) return/throw`).
-## 2024-03-21 - [Data Fetching Waterfalls in Next.js Server Components]
+## 2024-03-21 - Data Fetching Waterfalls in Next.js Server Components
 **Learning:** Sequential await calls on un-started Promises block subsequent queries. In Next.js, `params` and `searchParams` are now asynchronous, and waiting for them before starting a database query creates a waterfall.
 **Action:** Start the database fetch Promise immediately (without `await`), then resolve it concurrently with the parameter Promises using `Promise.all()`.

--- a/src/app/[lang]/(shop)/shop/page.tsx
+++ b/src/app/[lang]/(shop)/shop/page.tsx
@@ -34,18 +34,23 @@ export default async function ShopPage(
         return result;
     };
 
-    const params = await props.params;
-    const searchParams = await props.searchParams;
+    // Start the DB fetch immediately without waiting for params to resolve
+    const categoriesPromise = adminDb.collection('categories').orderBy('nameEn', 'asc').get();
+
+    const [params, searchParams] = await Promise.all([
+        props.params,
+        props.searchParams
+    ]);
     const { lang } = params;
 
     // Parse the category from search parameters
     const categoryQuery = searchParams.category;
     const currentCategorySlug = typeof categoryQuery === 'string' ? categoryQuery : null;
 
-    // Execute data fetching in parallel where possible
+    // Execute dictionary fetch and await the already-started categories fetch in parallel
     const [dict, categoriesSnapshot] = await Promise.all([
         getDictionary(lang as Locale),
-        adminDb.collection('categories').orderBy('nameEn', 'asc').get()
+        categoriesPromise
     ]);
 
     const categories = categoriesSnapshot.docs.map(doc => 

--- a/src/app/[lang]/(shop)/shop/page.tsx
+++ b/src/app/[lang]/(shop)/shop/page.tsx
@@ -37,21 +37,16 @@ export default async function ShopPage(
     // Start the DB fetch immediately without waiting for params to resolve
     const categoriesPromise = adminDb.collection('categories').orderBy('nameEn', 'asc').get();
 
-    const [params, searchParams] = await Promise.all([
+    const [params, searchParams, categoriesSnapshot] = await Promise.all([
         props.params,
-        props.searchParams
+        props.searchParams,
+        categoriesPromise
     ]);
     const { lang } = params;
 
     // Parse the category from search parameters
     const categoryQuery = searchParams.category;
     const currentCategorySlug = typeof categoryQuery === 'string' ? categoryQuery : null;
-
-    // Execute dictionary fetch and await the already-started categories fetch in parallel
-    const [dict, categoriesSnapshot] = await Promise.all([
-        getDictionary(lang as Locale),
-        categoriesPromise
-    ]);
 
     const categories = categoriesSnapshot.docs.map(doc => 
         serializeFirestoreData(doc.id, doc.data()) as Category
@@ -72,7 +67,11 @@ export default async function ShopPage(
 
     productsQuery = productsQuery.orderBy('createdAt', 'desc');
 
-    const productsSnapshot = await productsQuery.get();
+    // Execute dictionary and products fetch in parallel
+    const [dict, productsSnapshot] = await Promise.all([
+        getDictionary(lang as Locale),
+        productsQuery.get()
+    ]);
     const productsList = productsSnapshot.docs.map(doc => 
         serializeFirestoreData(doc.id, doc.data()) as Product
     );


### PR DESCRIPTION
💡 **What:**
Initiated the `adminDb.collection('categories').orderBy('nameEn', 'asc').get()` fetch immediately instead of sequentially awaiting the `props.params` and `props.searchParams` Promises first. Both database and parameter Promises are now resolved concurrently using `Promise.all`.

🎯 **Why:**
In recent Next.js versions, `params` and `searchParams` are asynchronous. By awaiting them before triggering the database fetch, we introduced an unnecessary data fetching waterfall that blocks the database query from starting. Hoisting the query eliminates this sequential blocking.

📊 **Impact:**
Reduces TTFB (Time To First Byte) and overall server-side rendering time for the Shop page by allowing the database request and the internal parameter resolution to run in parallel.

🔬 **Measurement:**
Run `pnpm build` to verify standard rendering. Network tab profiling of TTFB in production environments will show a reduction equivalent to the time previously spent awaiting `params`.

---
*PR created automatically by Jules for task [6486562172219398724](https://jules.google.com/task/6486562172219398724) started by @gokaiorg*