### PR TITLE
⚡ Bolt: [performance improvement] Avoid data fetching waterfall on shop page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-24 - Prevent N+1 queries in Firestore lookups
 **Learning:** Using `Promise.all(items.map(... => adminDb.collection("...").doc(id).get()))` creates an N+1 query problem, causing multiple network roundtrips to Firestore. This significantly degrades backend performance, especially when checking out carts with multiple items.
 **Action:** Always batch Firestore document lookups by ID into a single network call using `adminDb.getAll(...documentRefs)` instead of looping. Note that `getAll()` expects arguments to be spread and requires at least one document reference, so always add an empty array check (`if (items.length === 0) return/throw`).
+## 2024-05-30 - Unhandled Rejections in Concurrent Data Fetching
+**Learning:** When starting independent data fetches concurrently in Next.js Server Components, any un-awaited promises that fail while other promises are still resolving or failing will cause an unhandled promise rejection. This can crash Node.js or cause Next.js builds to fail if they aren't caught correctly.
+**Action:** Always attach a dummy `.catch(() => {})` to floating promises that are started concurrently and may not be explicitly awaited inside a `Promise.all`, or ensure they are explicitly included inside the `Promise.all` array right from the start.

--- a/src/app/[lang]/(shop)/shop/page.tsx
+++ b/src/app/[lang]/(shop)/shop/page.tsx
@@ -46,23 +46,21 @@ export default async function ShopPage(
     const dictPromise = getDictionary(lang as Locale);
     const categoriesPromise = adminDb.collection('categories').orderBy('nameEn', 'asc').get();
 
-    // If no category filter is applied, we can start fetching products concurrently to reduce TTFB
-    // We attach a dummy catch to prevent unhandled promise rejections if Promise.all fails before we await this.
-    let productsPromise: Promise<FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>> | undefined;
-    if (!currentCategorySlug) {
-        productsPromise = adminDb.collection('products').orderBy('createdAt', 'desc').get();
-        productsPromise.catch(() => {});
-    }
+    const productsPromise = !currentCategorySlug
+        ? adminDb.collection('products').orderBy('createdAt', 'desc').get()
+        : null;
 
-    // Await dictionary and categories as an explicit tuple to maintain typing,
-    // and let productsPromise run in the background (to be awaited later if needed).
-    const [dict, categoriesSnapshot] = await Promise.all([dictPromise, categoriesPromise]);
+    const [dict, categoriesSnapshot, preFetchedProducts] = await Promise.all([
+        dictPromise,
+        categoriesPromise,
+        productsPromise
+    ]);
 
     const categories = categoriesSnapshot.docs.map(doc => 
         serializeFirestoreData(doc.id, doc.data()) as Category
     );
 
-    let productsSnapshot;
+    let productsSnapshot: FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>;
     if (currentCategorySlug) {
         // We must wait to build the query for products based on the requested category
         let productsQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = adminDb.collection('products');
@@ -77,7 +75,8 @@ export default async function ShopPage(
         productsSnapshot = await productsQuery.get();
     } else {
         // Use the concurrently started products fetch result
-        productsSnapshot = await productsPromise!;
+        if (!preFetchedProducts) throw new Error("Products fetch failed to initialize");
+        productsSnapshot = preFetchedProducts;
     }
     const productsList = productsSnapshot.docs.map(doc => 
         serializeFirestoreData(doc.id, doc.data()) as Product

--- a/src/app/[lang]/(shop)/shop/page.tsx
+++ b/src/app/[lang]/(shop)/shop/page.tsx
@@ -42,32 +42,43 @@ export default async function ShopPage(
     const categoryQuery = searchParams.category;
     const currentCategorySlug = typeof categoryQuery === 'string' ? categoryQuery : null;
 
-    // Execute data fetching in parallel where possible
-    const [dict, categoriesSnapshot] = await Promise.all([
-        getDictionary(lang as Locale),
-        adminDb.collection('categories').orderBy('nameEn', 'asc').get()
-    ]);
+    // Optimization: Avoid data fetching waterfall by starting independent requests concurrently
+    const dictPromise = getDictionary(lang as Locale);
+    const categoriesPromise = adminDb.collection('categories').orderBy('nameEn', 'asc').get();
+
+    // If no category filter is applied, we can start fetching products concurrently to reduce TTFB
+    // We attach a dummy catch to prevent unhandled promise rejections if Promise.all fails before we await this.
+    let productsPromise: Promise<FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>> | undefined;
+    if (!currentCategorySlug) {
+        productsPromise = adminDb.collection('products').orderBy('createdAt', 'desc').get();
+        productsPromise.catch(() => {});
+    }
+
+    // Await dictionary and categories as an explicit tuple to maintain typing,
+    // and let productsPromise run in the background (to be awaited later if needed).
+    const [dict, categoriesSnapshot] = await Promise.all([dictPromise, categoriesPromise]);
 
     const categories = categoriesSnapshot.docs.map(doc => 
         serializeFirestoreData(doc.id, doc.data()) as Category
     );
 
-    // Build the query for products based on the requested category
-    let productsQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = adminDb.collection('products');
-    
+    let productsSnapshot;
     if (currentCategorySlug) {
-        // We first need the categoryId to query products
+        // We must wait to build the query for products based on the requested category
+        let productsQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = adminDb.collection('products');
         const catId = categories.find((c: Category) => lang === 'fr' ? c.slugFr === currentCategorySlug : c.slugEn === currentCategorySlug)?.id;
+
         if (catId) {
             productsQuery = productsQuery.where('categoryId', '==', catId);
         } else {
             productsQuery = productsQuery.where('categoryId', '==', 'NOT_FOUND');
         }
+        productsQuery = productsQuery.orderBy('createdAt', 'desc');
+        productsSnapshot = await productsQuery.get();
+    } else {
+        // Use the concurrently started products fetch result
+        productsSnapshot = await productsPromise!;
     }
-
-    productsQuery = productsQuery.orderBy('createdAt', 'desc');
-
-    const productsSnapshot = await productsQuery.get();
     const productsList = productsSnapshot.docs.map(doc => 
         serializeFirestoreData(doc.id, doc.data()) as Product
     );


### PR DESCRIPTION
💡 What: Avoid data fetching waterfall by starting independent requests concurrently for the Shop page.
🎯 Why: The original logic sequentially fetched the localization dictionary and the categories, and then constructed a query to fetch products. When no category filter is applied, the products query does not depend on the category request. This creates a data-fetching waterfall that delays rendering. 
📊 Impact: Reduces Time to First Byte (TTFB) significantly by resolving independent database queries in parallel. 
🔬 Measurement: Verify TTFB via network panel loading the base `/[lang]/shop` page without query parameters vs with query parameters.

---
*PR created automatically by Jules for task [696878751684925551](https://jules.google.com/task/696878751684925551) started by @gokaiorg*