### PR TITLE
⚡ Bolt: [Performance Improvement] Prevent unnecessary re-renders in HeaderContent

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Prevent N+1 queries in Firestore lookups
 **Learning:** Using `Promise.all(items.map(... => adminDb.collection("...").doc(id).get()))` creates an N+1 query problem, causing multiple network roundtrips to Firestore. This significantly degrades backend performance, especially when checking out carts with multiple items.
 **Action:** Always batch Firestore document lookups by ID into a single network call using `adminDb.getAll(...documentRefs)` instead of looping. Note that `getAll()` expects arguments to be spread and requires at least one document reference, so always add an empty array check (`if (items.length === 0) return/throw`).
+
+## 2024-05-24 - [Plan Review Groundedness Rule]
+**Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
+**Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { useSession, signOut, SessionProvider } from "next-auth/react";
+import { SessionProvider } from "next-auth/react";
 import { ThemeToggle } from "./ThemeToggle";
 import { LangToggle } from "./LangToggle";
 import { AccountToggle } from "./AccountToggle";
@@ -11,8 +11,10 @@ import { CartSheet } from "../cart/CartSheet";
 import { MobileNav } from "./MobileNav";
 
 function HeaderContent({ lang, dict }: { lang: string, dict: any }) {
-    const { status } = useSession();
-
+    // ⚡ Bolt Optimization:
+    // Removed unused useSession() hook from this component.
+    // Previously, calling useSession() here caused the entire HeaderContent
+    // (and all its children) to unnecessarily re-render on every session state change.
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-8">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,10 +11,6 @@ import { CartSheet } from "../cart/CartSheet";
 import { MobileNav } from "./MobileNav";
 
 function HeaderContent({ lang, dict }: { lang: string, dict: any }) {
-    // ⚡ Bolt Optimization:
-    // Removed unused useSession() hook from this component.
-    // Previously, calling useSession() here caused the entire HeaderContent
-    // (and all its children) to unnecessarily re-render on every session state change.
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-8">


### PR DESCRIPTION
**💡 What:** 
Removed the unused `useSession()` hook and its associated imports from `src/components/layout/Header.tsx`.

**🎯 Why:**
Calling `useSession()` attaches the component to the session context. Even if the extracted `status` variable is unused, it forces `HeaderContent` (and all its nested child components, like the navigation menus) to re-render unnecessarily every time the session state updates (e.g., during periodic NextAuth background refreshes). Removing the hook prevents these unnecessary re-renders.

**📊 Impact:** 
Reduces unnecessary client-side React component re-renders for the global header layout.

**🔬 Measurement:** 
This can be verified using the React DevTools Profiler by observing that `HeaderContent` no longer re-renders when the session context changes, or by analyzing React's render cycles.

---
*PR created automatically by Jules for task [9985646090612912190](https://jules.google.com/task/9985646090612912190) started by @gokaiorg*