### PR TITLE
⚡ Bolt: [performance improvement] Remove unused useSession hook from HeaderContent

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Prevent N+1 queries in Firestore lookups
 **Learning:** Using `Promise.all(items.map(... => adminDb.collection("...").doc(id).get()))` creates an N+1 query problem, causing multiple network roundtrips to Firestore. This significantly degrades backend performance, especially when checking out carts with multiple items.
 **Action:** Always batch Firestore document lookups by ID into a single network call using `adminDb.getAll(...documentRefs)` instead of looping. Note that `getAll()` expects arguments to be spread and requires at least one document reference, so always add an empty array check (`if (items.length === 0) return/throw`).
+
+## 2025-05-18 - Remove unnecessary `useSession` hooks
+**Learning:** Subscribing to `useSession()` from `next-auth/react` in components that don't actually render user session data forces those components to re-render whenever the global session state changes, which can lead to cascading re-renders in global components like `Header`.
+**Action:** Audit components importing `useSession`. If its returned values (e.g., `session`, `status`) are destructured but ultimately unused, remove the hook entirely to prevent unnecessary context subscriptions and improve client-side rendering performance.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { useSession, signOut, SessionProvider } from "next-auth/react";
+import { SessionProvider } from "next-auth/react";
 import { ThemeToggle } from "./ThemeToggle";
 import { LangToggle } from "./LangToggle";
 import { AccountToggle } from "./AccountToggle";
@@ -11,8 +11,9 @@ import { CartSheet } from "../cart/CartSheet";
 import { MobileNav } from "./MobileNav";
 
 function HeaderContent({ lang, dict }: { lang: string, dict: any }) {
-    const { status } = useSession();
-
+    // ⚡ Bolt Optimization: Removed unused useSession hook
+    // Subscribing to useSession causes the component to re-render whenever the session state changes.
+    // Since HeaderContent doesn't actively use the session, removing it prevents unnecessary cascading re-renders.
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-8">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,9 +11,6 @@ import { CartSheet } from "../cart/CartSheet";
 import { MobileNav } from "./MobileNav";
 
 function HeaderContent({ lang, dict }: { lang: string, dict: any }) {
-    // ⚡ Bolt Optimization: Removed unused useSession hook
-    // Subscribing to useSession causes the component to re-render whenever the session state changes.
-    // Since HeaderContent doesn't actively use the session, removing it prevents unnecessary cascading re-renders.
     return (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-8">


### PR DESCRIPTION
**💡 What:**
Removed the `useSession` hook from the `HeaderContent` component (in `src/components/layout/Header.tsx`).

**🎯 Why:**
The component was extracting `const { status } = useSession()`, but `status` was never actually used in the render tree. By calling `useSession`, the component hooks into the NextAuth context and will unnecessarily re-render every time the authentication session state changes. Removing the hook prevents these superfluous client-side re-renders, making the global header lighter and more efficient.

**📊 Impact:**
Reduces unnecessary re-renders of the global `HeaderContent` component on session state changes.

**🔬 Measurement:**
Use React DevTools Profiler to verify that `HeaderContent` no longer re-renders when authentication state changes (e.g., logging in or logging out via the `AccountToggle` component).

---
*PR created automatically by Jules for task [5537067473559949264](https://jules.google.com/task/5537067473559949264) started by @gokaiorg*