### PR TITLE
🎨 Palette: [UX improvement] Enhance navigation state and loading fallbacks

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,10 @@
 ## $(date +%Y-%m-%d) - Consistent SSR/Hydration Skeletons for Interactive Components
 **Learning:** Using generic HTML elements (like a `<div>`) as a loading skeleton or SSR fallback for complex interactive components (like shadcn/radix buttons with variants) causes layout shifts and semantic inconsistency before hydration.
 **Action:** For SSR/unmounted fallback states of interactive components, use structurally equivalent disabled semantic elements (e.g., a disabled `Button` with the same sizing variants) rather than generic divs.
+## 2025-04-28 - Active Navigation State
+**Learning:** Next.js Server Components require `"use client"` when using `usePathname()` to conditionally render active navigation states. However, adding this boundary at the navigation component level (`PrimaryNav.tsx`) is very safe and prevents having to convert the entire layout to a client component.
+**Action:** Always verify if a component needs a client boundary before adding hooks, and isolate the client boundary to the smallest possible leaf component.
+
+## 2025-04-28 - Accessible Skeletons vs Layout Shift
+**Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
+**Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.

--- a/src/components/admin/SeedDemoDataButton.tsx
+++ b/src/components/admin/SeedDemoDataButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTransition } from "react";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { seedDemoData } from "@/actions/admin";
@@ -30,7 +31,8 @@ export function SeedDemoDataButton({ dict }: {
 
     return (
         <Button variant="destructive" onClick={handleSeed} disabled={isPending}>
-            {isPending ? "..." : dict.dashboard_seedButton}
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {dict.dashboard_seedButton}
         </Button>
     );
 }

--- a/src/components/layout/AccountToggle.tsx
+++ b/src/components/layout/AccountToggle.tsx
@@ -19,7 +19,12 @@ export function AccountToggle({ lang, dict }: { lang: string, dict: any }) {
     const { data: session, status } = useSession()
 
     if (status === "loading") {
-        return <div className="h-8 w-16 animate-pulse rounded-md bg-muted"></div>
+        return (
+            <Button variant="ghost" size="icon" disabled>
+                <User className="h-[1.2rem] w-[1.2rem] opacity-50" />
+                <span className="sr-only">Account</span>
+            </Button>
+        )
     }
 
     if (session) {

--- a/src/components/layout/AccountToggle.tsx
+++ b/src/components/layout/AccountToggle.tsx
@@ -22,7 +22,7 @@ export function AccountToggle({ lang, dict }: { lang: string, dict: any }) {
         return (
             <Button variant="ghost" size="icon" disabled>
                 <User className="h-[1.2rem] w-[1.2rem] opacity-50" />
-                <span className="sr-only">Account</span>
+                <span className="sr-only">{dict.account || "Account"}</span>
             </Button>
         )
     }
@@ -33,7 +33,7 @@ export function AccountToggle({ lang, dict }: { lang: string, dict: any }) {
                 <DropdownMenuTrigger asChild>
                     <Button variant="ghost" size="icon">
                         <User className="h-[1.2rem] w-[1.2rem]" />
-                        <span className="sr-only">Account</span>
+                        <span className="sr-only">{dict.account || "Account"}</span>
                     </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
@@ -55,7 +55,7 @@ export function AccountToggle({ lang, dict }: { lang: string, dict: any }) {
         <AuthSheet dict={dict.auth || {}}>
             <Button variant="ghost" size="icon">
                 <User className="h-[1.2rem] w-[1.2rem]" />
-                <span className="sr-only">Account</span>
+                <span className="sr-only">{dict.account || "Account"}</span>
             </Button>
         </AuthSheet>
     )

--- a/src/components/layout/PrimaryNav.tsx
+++ b/src/components/layout/PrimaryNav.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import React from "react";
+import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 interface PrimaryNavProps {
@@ -10,19 +13,31 @@ interface PrimaryNavProps {
 }
 
 export function PrimaryNav({ lang, dict, className, onNavClick }: PrimaryNavProps) {
+    const pathname = usePathname();
+    const isShopActive = pathname?.includes(`/${lang}/shop`);
+    const isAboutActive = pathname?.includes(`/${lang}/about`);
+
     return (
         <nav className={cn("gap-6", className)}>
             <Link
                 href={`/${lang}/shop`}
                 onClick={onNavClick}
-                className="flex items-center text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                aria-current={isShopActive ? "page" : undefined}
+                className={cn(
+                    "flex items-center text-sm font-medium transition-colors hover:text-foreground",
+                    isShopActive ? "text-foreground" : "text-muted-foreground"
+                )}
             >
                 {dict.shop}
             </Link>
             <Link
                 href={`/${lang}/about`}
                 onClick={onNavClick}
-                className="flex items-center text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                aria-current={isAboutActive ? "page" : undefined}
+                className={cn(
+                    "flex items-center text-sm font-medium transition-colors hover:text-foreground",
+                    isAboutActive ? "text-foreground" : "text-muted-foreground"
+                )}
             >
                 {dict.about}
             </Link>


### PR DESCRIPTION
💡 **What:**
- Added `aria-current="page"` and visual active/inactive states to `PrimaryNav` links based on the current pathname.
- Replaced the generic `div` loading skeleton in `AccountToggle` with a structurally equivalent disabled `Button` containing the user icon.
- Replaced the hardcoded `...` pending text in `SeedDemoDataButton` with an animated `Loader2` spinner.

🎯 **Why:**
- Users couldn't easily tell which page they were currently viewing in the navigation.
- The account toggle's loading state caused a layout shift (CLS) in the header because the skeleton `w-16` was wider than the loaded icon button.
- The "Seed Demo Data" button's loading state felt unpolished and changed the button's width abruptly when clicked.

♿ **Accessibility:**
- Adding `aria-current="page"` explicitly informs screen readers of the active navigation item.
- Using a disabled `Button` with a `sr-only` span provides better context to screen readers than an empty animated `div`.
- Preserving the button text while adding a spinner ensures context isn't lost during async operations.

---
*PR created automatically by Jules for task [12987256730453498861](https://jules.google.com/task/12987256730453498861) started by @gokaiorg*