### PR TITLE
🎨 Palette: [UX improvement] Fix AccountToggle loading layout shift

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## $(date +%Y-%m-%d) - Consistent SSR/Hydration Skeletons for Interactive Components
 **Learning:** Using generic HTML elements (like a `<div>`) as a loading skeleton or SSR fallback for complex interactive components (like shadcn/radix buttons with variants) causes layout shifts and semantic inconsistency before hydration.
 **Action:** For SSR/unmounted fallback states of interactive components, use structurally equivalent disabled semantic elements (e.g., a disabled `Button` with the same sizing variants) rather than generic divs.
+## 2024-04-29 - Loading Skeleton Layout Shifts
+**Learning:** Loading skeleton dimensions that do not perfectly match the final loaded component size (e.g., `h-8 w-16` placeholder for a `size-9` icon button) cause jarring layout shifts when the async state resolves.
+**Action:** Always ensure fallback/loading skeleton UI elements match the exact dimensions of their interactive counterparts to provide a seamless, non-janky UX loading experience.

--- a/src/components/layout/AccountToggle.tsx
+++ b/src/components/layout/AccountToggle.tsx
@@ -19,7 +19,7 @@ export function AccountToggle({ lang, dict }: { lang: string, dict: any }) {
     const { data: session, status } = useSession()
 
     if (status === "loading") {
-        return <div className="h-8 w-16 animate-pulse rounded-md bg-muted"></div>
+        return <div className="size-9 animate-pulse rounded-md bg-muted"></div>
     }
 
     if (session) {


### PR DESCRIPTION
💡 What: Updated the loading placeholder in `AccountToggle.tsx` to match the dimensions of the final loaded icon button (`size-9` instead of `h-8 w-16`).
🎯 Why: Prevents a jarring layout shift (jank) when the authentication state resolves from loading to loaded, making the interface feel more stable and polished.
📸 Before/After: The loading skeleton is now a square that matches the user icon button instead of a wider rectangle.
♿ Accessibility: Preserves the visual loading cue (`animate-pulse`) while improving the perceptual stability of the header.

---
*PR created automatically by Jules for task [16534227389301113810](https://jules.google.com/task/16534227389301113810) started by @gokaiorg*