### PR TITLE
🎨 Palette: [UX improvement] Add sr-only labels to admin edit links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2025-05-08 - Accessible Links vs Actionable Icons
+**Learning:** Using an icon inside an `a` or `Link` tag, visually styled as a `Button`, without accompanying text makes the link completely inaccessible to screen reader users (it announces as just "link" or nothing). Adding `aria-label` directly to the `Link` component can sometimes be stripped or handled inconsistently by Next.js or React depending on version.
+**Action:** The safest and most robust way to make icon-only links accessible in React is to insert a visually hidden `span` with the `sr-only` class *inside* the link element, containing the localized descriptive text.

--- a/src/app/[lang]/admin/categories/page.tsx
+++ b/src/app/[lang]/admin/categories/page.tsx
@@ -84,6 +84,7 @@ export default async function AdminCategoriesPage({ params }: { params: Promise<
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/categories/${category.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">{dict.admin.categories_edit || 'Edit Category'}</span>
                                             </Link>
                                         </Button>
                                     </td>

--- a/src/app/[lang]/admin/pages/page.tsx
+++ b/src/app/[lang]/admin/pages/page.tsx
@@ -67,6 +67,7 @@ export default async function AdminPagesPage({ params }: { params: Promise<{ lan
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/pages/${page.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">{dict.admin.pages_edit || 'Edit Page'}</span>
                                             </Link>
                                         </Button>
                                     </td>

--- a/src/app/[lang]/admin/products/page.tsx
+++ b/src/app/[lang]/admin/products/page.tsx
@@ -101,6 +101,7 @@ export default async function AdminProductsPage({ params }: { params: Promise<{ 
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/products/${product.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">{dict.admin.products_edit || 'Edit Product'}</span>
                                             </Link>
                                         </Button>
                                     </td>


### PR DESCRIPTION
### 💡 What
Added accessible `sr-only` span tags inside the icon-only "Edit" links (the `Pencil` icon) across the admin listing tables (Categories, Pages, and Products).

### 🎯 Why
Without this change, screen readers will only announce these edit buttons as "link" without any context, making the admin dashboard tables very difficult to navigate for visually impaired users. This small change adds standard HTML accessability patterns.

### ♿ Accessibility
- Fixed WCAG violation (Missing accessible name for link)
- Added localized, context-aware descriptions for "Edit [Entity]"
- Relies on robust `sr-only` CSS rather than `aria-label` attribute on React Router links, ensuring consistent screen reader support.

---
*PR created automatically by Jules for task [8683502570163554332](https://jules.google.com/task/8683502570163554332) started by @gokaiorg*