### PR TITLE
⚡ Bolt: [performance improvement] Cache duplicate Firestore queries in dynamic routes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-05-09 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** In Next.js App Router applications, both `generateMetadata` and the main page component are executed during a single request lifecycle. While Next.js automatically deduplicates network requests made with the native `fetch` API, it **does not** automatically deduplicate direct database calls made via SDKs (like `firebase-admin`). This leads to duplicate database queries and increased TTFB.
+**Action:** Always wrap non-fetch data loading functions (such as Firestore queries) in Next.js Server Components with `React.cache()`. This ensures the expensive database operation is executed only once per request lifecycle, and its result is reused by both `generateMetadata` and the component.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,12 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt: Cache the page fetch to prevent duplicate Firestore queries between generateMetadata and the page component
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,30 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// ⚡ Bolt: Cache the product fetch to prevent duplicate Firestore queries between generateMetadata and the page component
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(slugField, slug);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -36,13 +43,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(slugField, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
**💡 What:** Extracted direct `firebase-admin` database queries into helper functions and wrapped them with `React.cache()` in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx`.

**🎯 Why:** In Next.js App Router, both `generateMetadata` and the default page export are executed within the same server request lifecycle. While Next.js automatically deduplicates native `fetch()` calls, it does not deduplicate third-party SDK calls like Firebase Admin. This resulted in identical Firestore `.get()` operations being executed twice sequentially per page load.

**📊 Impact:** Reduces database reads by 50% on these dynamic routes. Lowers server response time (TTFB) by eliminating the redundant network roundtrip.

**🔬 Measurement:** View Firestore execution logs to verify that the query is executed only once when hitting a product detail route. Observe decreased TTFB in Vercel Analytics or Network tab.

---
*PR created automatically by Jules for task [18372582734190732915](https://jules.google.com/task/18372582734190732915) started by @gokaiorg*