### PR TITLE
🎨 Palette: [UX improvement] Add icons to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-05-09 - [Password Toggle Icons]
+**Learning:** Replaced text "Show"/"Hide" labels with `Eye` and `EyeOff` icons from `lucide-react` in the password toggle input. Ensure `aria-hidden="true"` on the icons and keep `aria-label` on the button itself.
+**Action:** Consistently use recognized icons for password visibility toggles while preserving screen reader accessibility. Also, be mindful of `pnpm` versions matching the lockfile version to prevent massive unintended rewrites when running `pnpm install` during testing steps.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
### 💡 What
Replaced the raw text "Show" and "Hide" labels in the `LoginForm`'s password visibility toggle with the universally recognized `Eye` and `EyeOff` icons from the `lucide-react` library.

### 🎯 Why
Text-based toggles for password visibility can be clunky or slow to read for users. Standard icons improve visual polish, save horizontal space, and make the form's functionality instantly recognizable and more pleasant to use. 

### ♿ Accessibility
The icons are injected with `aria-hidden="true"` so they are safely ignored by screen readers, preventing redundant or confusing announcements. The parent `<Button>` retains its dynamic, descriptive `aria-label` ("Show password" / "Hide password"), ensuring the interactive element remains fully accessible for keyboard and screen reader users.

---
*PR created automatically by Jules for task [11291887184042201949](https://jules.google.com/task/11291887184042201949) started by @gokaiorg*