### PR TITLE
🎨 Palette: [UX improvement] Replace password visibility text with icon

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -129,11 +129,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 type="button"
                                 variant="ghost"
                                 size="sm"
-                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground"
+                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground cursor-pointer"
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**🎨 Palette: [UX improvement] Replace password visibility text with icon**

**💡 What:** 
Replaced the raw text "Show"/"Hide" labels in the password input toggle within `LoginForm.tsx` with standard `lucide-react` icons (`Eye` and `EyeOff`). Added standard cursor styling on hover.

**🎯 Why:**
Replacing plain text with universally recognized icons improves UI aesthetics, saves horizontal space, and aligns with modern design patterns. The existing component is internationalized using a `dict` prop, but the text on the button was hardcoded in English ("Show"/"Hide"). Using standard icons naturally resolves the visual localization issue without requiring dictionary updates.

**♿ Accessibility:**
* Maintained existing `aria-label` which dynamically toggles ("Show password" / "Hide password") to ensure the action is still correctly announced by screen readers.
* Added `aria-hidden="true"` directly to the SVG icons to prevent screen readers from redundantly announcing the icon's generic label over the button's explicit `aria-label`.

---
*PR created automatically by Jules for task [11732267928339210560](https://jules.google.com/task/11732267928339210560) started by @gokaiorg*