### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in updateProfile server action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+## 2024-05-11 - Server Action Import Order
+**Vulnerability:** Import statement order matters.
+**Learning:** During review, I placed an import inside a file but not at the top. While technically valid ES modules, it failed linting maintainability standards and was rejected.
+**Prevention:** Always place imports at the top of the file when modifying server actions.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { auth } from "@/auth";
 import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
@@ -57,6 +58,14 @@ export async function registerUser(formData: FormData) {
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
+
+    const session = await auth();
+    const userRole = (session?.user?.role || "").toLowerCase();
+
+    // Authorization check: user must be admin or updating their own profile
+    if (!session || (userRole !== "admin" && session.user?.id !== uid)) {
+        return { error: "Unauthorized" };
+    }
 
     try {
         const updateData: any = {};


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `updateProfile` server action in `src/actions/auth.ts` lacked authorization checks, allowing any authenticated user to update the profile of any other user via an Insecure Direct Object Reference (IDOR).
🎯 Impact: An attacker could potentially modify names, emails, and passwords of other accounts without authorization, including admin accounts.
🔧 Fix: Added an authorization check using the `auth()` hook to verify that the calling session is authenticated and either holds the 'admin' role or the session ID matches the target `uid`.
✅ Verification: Ran `pnpm lint` and `pnpm build` locally. Both succeeded.

---
*PR created automatically by Jules for task [4602315479395196550](https://jules.google.com/task/4602315479395196550) started by @gokaiorg*