### PR TITLE
🎨 Palette: Intuitive Password Visibility Icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
### 💡 What
Replaced the plain text "Show"/"Hide" labels in the password visibility toggle button with intuitive `Eye` and `EyeOff` icons from the existing `lucide-react` dependency.

### 🎯 Why
Using standard icons for password visibility toggles is a universally recognized UX pattern that reduces cognitive load, improves aesthetic polish, and saves horizontal space in mobile layouts compared to localized text strings.

### 📸 Before/After
*(Visuals verified via Playwright headless testing during pre-commit)*
- Before: Text button reading "Show" or "Hide"
- After: Icon button displaying `<Eye />` or `<EyeOff />`

### ♿ Accessibility
Maintained the existing explicit `aria-label` attribute on the parent `<Button>` for screen readers ("Show password" / "Hide password") while securing the visual icons with `aria-hidden="true"`. This prevents screen readers from redundantly announcing the raw SVGs while ensuring total semantic clarity for non-visual users.

---
*PR created automatically by Jules for task [13321025360607255954](https://jules.google.com/task/13321025360607255954) started by @gokaiorg*