### PR TITLE
🎨 Palette: [UX] Replace password toggle text with standard icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**What:** Replaced the plain text "Show" and "Hide" labels inside the password input visibility toggle in `LoginForm.tsx` with standard `Eye` and `EyeOff` icons from `lucide-react`.

**Why:** Using universally recognized icons for password visibility toggling provides a cleaner, more intuitive user experience and reduces visual clutter in the form.

**Accessibility:** Kept the existing `aria-label` attribute on the parent `<Button>` to announce the "Show password" or "Hide password" action to screen readers, and explicitly added `aria-hidden="true"` to the new Lucide icons to prevent screen readers from redundantly announcing the icons.

---
*PR created automatically by Jules for task [1130319461819025097](https://jules.google.com/task/1130319461819025097) started by @gokaiorg*