### PR TITLE
🎨 Palette: [UX improvement] Replace text labels with icons for password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the raw text "Show" and "Hide" labels on the password visibility toggle in `LoginForm` with standard `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** Using standard visual icons for password toggles is a more intuitive and widely recognized UX pattern than raw text labels. It cleans up the UI and makes the interaction feel more natural.

♿ **Accessibility:** Added `aria-hidden="true"` to the new icons to prevent redundancy, as the parent `<Button>` element already provides a descriptive explicit `aria-label` ("Show password" / "Hide password") for screen readers.

---
*PR created automatically by Jules for task [3032614232876611581](https://jules.google.com/task/3032614232876611581) started by @gokaiorg*