### PR TITLE
⚡ Bolt: Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-05-14 - Deduplicate App Router Database Calls
+**Learning:** In Next.js App Router, extracting shared non-fetch database calls (like Firebase Admin queries) from `generateMetadata` and the main page component and wrapping them in `React.cache()` eliminates duplicate N+1 style server-side requests across a single render lifecycle.
+**Action:** Always wrap direct database/SDK calls with `React.cache()` when they are utilized in both metadata generation and page rendering to optimize TTFB and reduce database load.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import React from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = React.cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
 import Image from "next/image";
+import React from "react";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
@@ -11,18 +12,25 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+// ⚡ Bolt: Cache the product query to prevent duplicate Firestore requests
+// during both generateMetadata and the page component render
+const getProductBySlug = React.cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProductBySlug(lang, slug);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +43,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(lang, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
### 💡 What
Extracted and wrapped direct Firestore queries with `React.cache()` in both standard page and product page server components.

### 🎯 Why
In Next.js App Router, `generateMetadata` and the page component execute in parallel during a single server request. Native `fetch()` requests are automatically deduplicated by Next.js, but direct database calls via SDKs (like `firebase-admin`) are not. This was causing a classic N+1 style inefficiency where the server hit Firestore twice for the exact same document on every page load.

### 📊 Impact
* Eliminates 1 duplicate database roundtrip per page load for dynamic slugs and products.
* Halves the read operations billed in Firestore for these routes.
* Reduces overall Time To First Byte (TTFB) and server-side CPU utilization.

### 🔬 Measurement
To verify, you can monitor the network activity in the Firebase console or add `console.log` statements inside the cached functions. Before this PR, the log would print twice per page load; after, it prints only once. Run `pnpm build` to verify there are no regressions in static or dynamic page generation.

---
*PR created automatically by Jules for task [9666876024954530998](https://jules.google.com/task/9666876024954530998) started by @gokaiorg*