### PR TITLE
🎨 Palette: Replace text labels with icons for password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced the hardcoded 'Show' and 'Hide' text strings with `Eye` and `EyeOff` icons from `lucide-react` in the password visibility toggle button within the `LoginForm` component.
**🎯 Why:** The use of recognizable icons for password visibility is a widespread UX pattern that is more intuitive and visually cohesive than raw text. It also eliminates hardcoded English strings, which is beneficial since the form supports multiple languages via a dictionary prop.
**📸 Before/After:** Before, the input field featured text buttons ('Show'/'Hide'). Now, it uses standard icons.
**♿ Accessibility:** The parent `<Button>` retains its descriptive `aria-label` ("Show password" / "Hide password"), while the new SVG icons are explicitly marked with `aria-hidden="true"` to prevent redundant or confusing screen reader announcements.

---
*PR created automatically by Jules for task [9437604886539657955](https://jules.google.com/task/9437604886539657955) started by @gokaiorg*