### PR TITLE
⚡ Bolt: [performance improvement] Cache duplicate Firestore queries in Next.js pages

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,23 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// Cache the Firestore query to prevent duplicate calls during SSR
+// between generateMetadata and the page component
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot;
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +44,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
⚡ Bolt: Cache Firestore Queries during SSR

### 💡 What
Wrapped the Firestore query data fetching functions in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`.

### 🎯 Why
In the Next.js App Router, it's common practice to fetch the same data in both `generateMetadata` and the main Page component. When using native `fetch()`, Next.js automatically deduplicates identical requests during the server-rendering phase. However, when using direct backend SDKs like Firebase Admin (`adminDb.collection(...).get()`), Next.js does *not* automatically deduplicate these calls. This was causing the exact same document to be queried from Firestore twice per page load, unnecessarily increasing latency and Firestore read costs. By extracting the query into a helper function and wrapping it in `React.cache()`, we enforce that the database query only executes once per request lifecycle.

### 📊 Impact
*   Reduces database reads per page view by 50% for dynamic pages and product pages.
*   Improves Time To First Byte (TTFB) by eliminating the latency of the redundant backend network call.

### 🔬 Measurement
Verify by adding a simple `console.log("Fetching DB")` inside the cached function, loading the page, and observing the server terminal. You should see only one log line per request instead of two.

---
*PR created automatically by Jules for task [15870223943511995822](https://jules.google.com/task/15870223943511995822) started by @gokaiorg*