### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## $(date +%Y-%m-%d) - Password Visibility Toggle Icons UX
+**Learning:** Using plain text ("Show" / "Hide") for password visibility toggles is less recognizable and takes up more space than standard iconography. However, when replacing text with icons, the parent interactive element must retain its context for screen readers.
+**Action:** Replace plain text toggles with standard `Eye` and `EyeOff` icons from `lucide-react`. Equip the icons with `aria-hidden="true"` and ensure the parent `<Button>` maintains an explicit, dynamic `aria-label` (e.g., "Show password" or "Hide password") to preserve accessibility.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**What:** Replaced the plain text "Show" / "Hide" toggles in the password input field with standard `Eye` and `EyeOff` icons from `lucide-react`.

**Why:** Using standard iconography for password visibility is a universally recognized UX pattern. It makes the interface more intuitive, reduces visual clutter, and provides immediate visual context.

**Accessibility:** Ensured screen reader accessibility is preserved by keeping the `aria-label` attribute on the parent `<Button>` component (which dynamically updates between "Show password" and "Hide password") and adding `aria-hidden="true"` to the newly introduced icons to prevent double-reading.

---
*PR created automatically by Jules for task [2762376950679900569](https://jules.google.com/task/2762376950679900569) started by @gokaiorg*