### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateProfile server action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,12 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+
+## 2026-05-17 - [IDOR in Next.js Server Actions]
+**Vulnerability:** Next.js Server Actions bypass route-level middleware protection (). The `updateProfile` action was vulnerable to IDOR because it accepted a `uid` parameter from the client and modified that user's profile without verifying if the authenticated session belonged to that `uid`.
+**Learning:** Global middleware protection does not guarantee authorization for internal Server Action executions. Relying on client-provided IDs for user-specific mutations without server-side validation is a critical security risk.
+**Prevention:** Always implement explicit session authorization checks directly within sensitive Next.js Server Actions (e.g., `const session = await auth(); if (!session || session.user.id !== uid)`) to enforce authorization boundaries.
+## 2024-05-17 - [IDOR in Next.js Server Actions]
+**Vulnerability:** Next.js Server Actions bypass route-level middleware protection (`middleware.ts`). The `updateProfile` action was vulnerable to IDOR because it accepted a `uid` parameter from the client and modified that user's profile without verifying if the authenticated session belonged to that `uid`.
+**Learning:** Global middleware protection does not guarantee authorization for internal Server Action executions. Relying on client-provided IDs for user-specific mutations without server-side validation is a critical security risk.
+**Prevention:** Always implement explicit session authorization checks directly within sensitive Next.js Server Actions (e.g., `const session = await auth(); if (!session || session.user.id !== uid)`) to enforce authorization boundaries.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,13 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    const userRole = (session?.user?.role || "").toLowerCase();
+
+    if (!session || !session.user || (session.user.id !== uid && userRole !== "admin")) {
+        return { error: "Unauthorized" };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Insecure Direct Object Reference (IDOR) in `src/actions/auth.ts`. The `updateProfile` server action accepted a `uid` parameter from the client and executed Firebase Admin updates without verifying that the caller actually owned that `uid`. Next.js Server Actions bypass `middleware.ts` protections.
🎯 Impact: A malicious authenticated user could update the `email` and `password` of any other user in the database (including admins) by simply calling the server action with a different user's UID, leading to total account takeover.
🔧 Fix: Imported the NextAuth `auth()` session directly inside the `updateProfile` action. Added an explicit check to verify that `session.user.id` matches the target `uid` parameter (or that the caller possesses the "admin" role). If the check fails, it safely returns `{ error: "Unauthorized" }`.
✅ Verification: Ran `pnpm lint` and `pnpm build`. Lockfile churn was reverted. Verified that the action securely handles missing or mismatched sessions.

---
*PR created automatically by Jules for task [14825662176244884496](https://jules.google.com/task/14825662176244884496) started by @gokaiorg*