### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-24 - Deduplicate Firestore queries across generateMetadata and Page components
+**Learning:** In Next.js App Router applications, when fetching data (e.g., from Firestore via `firebase-admin`) in both `generateMetadata` and the default Page component, the query executes twice per request lifecycle. Unlike the native `fetch` API, these direct SDK calls are not automatically memoized by Next.js.
+**Action:** Always extract shared database fetching logic into a helper function and wrap it with `React.cache()`. This ensures the expensive query only executes once per request lifecycle, reducing database reads and improving server-side rendering performance.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,24 +6,40 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (slug: string, lang: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
     
     if (snapshot.empty) {
+        return null;
+    }
+
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    return {
+        ...data,
+        id: doc.id,
+        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
+        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
+    } as Product;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const product = await getProductBySlug(slug, lang);
+
+    if (!product) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,21 +51,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const product = await getProductBySlug(slug, lang);
 
-    if (snapshot.empty) {
+    if (!product) {
         notFound();
     }
-
-    const doc = snapshot.docs[0];
-    const data = doc.data();
-    const product = {
-        ...data,
-        id: doc.id,
-        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
-        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
-    } as Product;
 
     const dict = await getDictionary(lang as Locale);
     const shopDict = dict.shop;


### PR DESCRIPTION
### 💡 What: 
Extracted redundant `firebase-admin` Firestore queries in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` into helper functions wrapped with `React.cache()`.

### 🎯 Why:
In the Next.js App Router, functions like `generateMetadata` and the Page component run within the same server request lifecycle. While Next.js automatically deduplicates native `fetch` requests, it does not automatically memoize direct SDK calls (like those from `firebase-admin`). Because these routes were querying Firestore in both `generateMetadata` and the default component, they were causing the exact same document retrieval queries to execute twice per request, wasting database reads and slightly delaying server rendering.

### 📊 Impact: 
Reduces Firestore reads by exactly 50% for dynamic page (`/[slug]`) and product page (`/product/[slug]`) visits, directly improving server-side TTFB (Time To First Byte).

### 🔬 Measurement:
The optimization can be verified locally or in a staging environment by adding console logs within the cached helper functions. Because `React.cache()` memoizes the result per-request, the log will only appear once per page load, whereas previously it would have logged twice. Additionally, production Firestore read billing should noticeably decrease for these specific collection accesses.

---
*PR created automatically by Jules for task [17630220001688324965](https://jules.google.com/task/17630220001688324965) started by @gokaiorg*