### PR TITLE
🎨 Palette: [UX improvement] Use standard icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2024-05-17 - [Interactive Toggle Icons]
+**Learning:** For interactive toggles like password visibility, raw text labels ("Show" / "Hide") are less intuitive than standard recognizable icons (`lucide-react` Eye/EyeOff).
+**Action:** Replace raw text labels with standard recognizable icons equipped with `aria-hidden="true"`, and ensure the explicit `aria-label` remains on the parent interactive element (e.g., `<Button>`).

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Replaced the "Show" and "Hide" raw text in the password visibility toggle of the `LoginForm` with standard `Eye` and `EyeOff` icons from `lucide-react`.
🎯 Why: Standard icons are more globally recognizable and intuitive for users interacting with password fields, providing a cleaner and more polished UI.
♿ Accessibility: The parent `<Button>` already possesses a dynamic, descriptive `aria-label` ("Show password" / "Hide password"). I added `aria-hidden="true"` to the newly introduced decorative icons to ensure screen readers do not read redundant information.

---
*PR created automatically by Jules for task [4796772819530116893](https://jules.google.com/task/4796772819530116893) started by @gokaiorg*