### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateProfile Server Action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+## 2024-05-25 - IDOR in Profile Update Server Action
+**Vulnerability:** CRITICAL Insecure Direct Object Reference (IDOR) / Missing Authorization in the `updateProfile` server action. The action accepted a `uid` and update data (name, email, password) but did not verify if the caller owned that `uid` or was an admin, allowing anyone to change any other user's credentials or email.
+**Learning:** Functions handling user data updates must always verify that the requester is authorized to modify the target resource, especially when IDs are passed as arguments to Server Actions.
+**Prevention:** Always verify `session?.user?.id === targetId` or `session?.user?.role === 'admin'` before allowing state mutations in Server Actions.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,13 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    const userRole = (session?.user?.role || "").toLowerCase();
+
+    if (session?.user?.id !== uid && userRole !== "admin") {
+        return { error: "Unauthorized" };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `updateProfile` server action in `src/actions/auth.ts` did not perform any authorization checks. Since it accepted a target `uid` as a parameter, any authenticated (or even unauthenticated, due to lack of checks) user could technically supply the `uid` of another user (or an admin) and overwrite their name, email, or password.
🎯 Impact: Complete account takeover, data modification, or privilege escalation (if an admin account was targeted).
🔧 Fix: Added explicit checks at the start of the Server Action using `await auth()` to ensure the caller's session ID matches the provided `uid`, or the caller has an `admin` role. Returns `{ error: "Unauthorized" }` if neither condition is met.
✅ Verification: Verified fix using `pnpm build` and `pnpm lint`. Logic passes static checks and conforms to the principle of least privilege.

---
*PR created automatically by Jules for task [13416410078329076986](https://jules.google.com/task/13416410078329076986) started by @gokaiorg*