### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2026-05-18 - Accessible Interactive Toggle Buttons
+**Learning:** When replacing raw text (like 'Show' or 'Hide') in interactive toggles with icons, it is crucial to maintain both screen reader accessibility and visual clarity without double-reading.
+**Action:** Use universally recognized icons (e.g., `Eye`, `EyeOff` from `lucide-react`) equipped with `aria-hidden="true"`, and explicitly set an `aria-label` on the parent interactive element (like the `<Button>`) to convey the current action (e.g., 'Show password', 'Hide password').

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
## 💡 What
Replaced the plain text "Show" and "Hide" labels inside the password visibility toggle button with standardized `Eye` and `EyeOff` icons from `lucide-react`.

## 🎯 Why
Raw text inside small interactive inputs can look unpolished and take up valuable space. By using universally recognized icons, the interface feels cleaner, more intuitive, and aligns with modern design patterns for authentication forms.

## ♿ Accessibility
The icons have been correctly hidden from screen readers using `aria-hidden="true"`, ensuring the screen reader only announces the descriptive `aria-label` already present on the parent `<Button>` ("Show password" / "Hide password"). This prevents double-reading and maintains full keyboard accessibility.

---
*PR created automatically by Jules for task [17838666527149093040](https://jules.google.com/task/17838666527149093040) started by @gokaiorg*