### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-05-19 - Next.js Cache Deduplication for Firestore
+**Learning:** In Next.js App Router, standard `fetch()` calls are automatically memoized by the framework. However, direct database queries using SDKs like `firebase-admin` are NOT deduplicated. This causes identical queries placed in both `generateMetadata` and the main Page component to execute twice per request lifecycle, doubling database reads and blocking TTFB.
+**Action:** Always wrap non-fetch data queries (like Firestore `get()` calls) inside Next.js server components with `React.cache()` to ensure they only execute once per server-rendered request.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,30 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductBySlug = cache(async (slug: string, slugField: string) => {
+    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
     
-    if (snapshot.empty) {
+    const doc = await getProductBySlug(slug, slugField);
+
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -36,13 +43,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
 
-    if (snapshot.empty) {
+    const doc = await getProductBySlug(slug, slugField);
+
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
💡 What: Wrapped direct `firebase-admin` database queries in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`.
🎯 Why: In the Next.js App Router, while native `fetch()` calls are automatically memoized, direct database SDK queries are not. Since both `generateMetadata` and the default Page component were executing the exact same Firestore query, this caused identical database reads to happen twice per request during Server-Side Rendering (SSR).
📊 Impact: Eliminates duplicate Firestore reads per request on both product and dynamic pages. Reduces database cost by ~50% for these routes and improves Time To First Byte (TTFB) by cutting out the latency of a redundant network call.
🔬 Measurement: Verify by checking Google Cloud Firestore read logs for a single page load before and after the change; the number of document reads for the page slug will decrease from 2 to 1.

---
*PR created automatically by Jules for task [1711219734464475351](https://jules.google.com/task/1711219734464475351) started by @gokaiorg*