### PR TITLE
🎨 Palette: [UX improvement] Use Eye icons for password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the raw text labels "Show" and "Hide" on the password visibility toggle in `LoginForm.tsx` with standard `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** To make the interface more intuitive and visually polished. Raw text labels inside an input field take up unnecessary horizontal space and look less modern than widely recognized iconography.

♿ **Accessibility:** The new icons are strictly equipped with `aria-hidden="true"`. The parent `<Button>` retains its screen-reader friendly `aria-label` which dynamically switches between "Show password" and "Hide password". This ensures visual polish without double-reading or confusing screen reader users.

---
*PR created automatically by Jules for task [15331032888095439324](https://jules.google.com/task/15331032888095439324) started by @gokaiorg*