### PR TITLE
🎨 Palette: [UX improvement] Replace text labels with icons in password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What**: 
Replaced the raw text labels ("Show" / "Hide") in the password visibility toggle of the `LoginForm` component with standard `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why**: 
Improves visual polish, uses universally recognizable icons which aids internationalization, and reduces visual clutter on the form.

**♿ Accessibility**: 
The parent button retains its explicit `aria-label` (e.g., "Show password"), and the newly introduced SVG icons are equipped with `aria-hidden="true"`. This ensures that screen readers read the clean, descriptive label rather than trying to interpret the SVG elements, maintaining a seamless experience for assistive technologies.

---
*PR created automatically by Jules for task [4167868023687613641](https://jules.google.com/task/4167868023687613641) started by @gokaiorg*