### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in profile update action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+## 2026-05-20 - [IDOR in User Profile Update Server Action]
+**Vulnerability:** The `updateProfile` server action in `src/actions/auth.ts` lacked authorization checks, allowing any user (or an unauthenticated user) to modify any profile by providing the target's `uid`.
+**Learning:** In Next.js, Server Actions bypass the route-level middleware protection defined in `src/middleware.ts`. Therefore, sensitive actions must explicitly verify the user's session and identity within the action itself to prevent IDOR and authorization bypass.
+**Prevention:** Always implement explicit session authorization checks directly within sensitive server actions (`const session = await auth(); if (!session?.user?.id || session.user.id !== uid && session.user.role?.toLowerCase() !== 'admin')`) to ensure the requester is authorized to modify the target resource.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,14 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    if (!session?.user?.id) {
+        return { error: "Unauthorized" };
+    }
+    if (session.user.id !== uid && session.user.role?.toLowerCase() !== "admin") {
+        return { error: "Forbidden: You can only update your own profile." };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `updateProfile` server action lacked authorization checks. Any user (or unauthenticated actor) could send a request to update another user's profile by providing their `uid`. This could be exploited to change passwords and takeover accounts.
🎯 Impact: Full account takeover for any user on the platform.
🔧 Fix: Added an authorization check to verify that the authenticated session's user ID matches the target `uid` being updated, or that the session user has an 'admin' role.
✅ Verification: Ran `pnpm build` and `pnpm lint` successfully. Evaluated logic via code review which confirmed the patch is correct and successfully remediates the vulnerability.

---
*PR created automatically by Jules for task [7613935166184814227](https://jules.google.com/task/7613935166184814227) started by @gokaiorg*