### PR TITLE
🎨 Palette: [UX improvement] Replace text with icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Password Visibility Icons vs Text
+**Learning:** Using raw text like "Show" or "Hide" for a password visibility toggle button is less universally understood, takes up horizontal space, and often relies on English when it should be localized.
+**Action:** Always replace raw text in password visibility toggles with standard UI icons (like `Eye` and `EyeOff` from `lucide-react`). Ensure the icons have `aria-hidden="true"` applied, and maintain the existing `aria-label` on the parent interactive `<Button>` element for screen reader accessibility.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the raw text "Show" and "Hide" in the `LoginForm` password visibility toggle with standard `Eye` and `EyeOff` icons from `lucide-react`.
🎯 **Why:** Standard icons are more universally recognizable, save horizontal space, and do not require localization unlike English text strings. 
📸 **Before/After:** See attached Playwright verification screenshots.
♿ **Accessibility:** Added `aria-hidden="true"` to the newly introduced icons to prevent screen readers from reading them. The existing `aria-label` on the parent `<Button>` remains the primary description for screen reader users.

---
*PR created automatically by Jules for task [12856118331251536190](https://jules.google.com/task/12856118331251536190) started by @gokaiorg*