### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate metadata database queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,10 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+\n## 2026-05-22 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** In Next.js App Router,  requests are automatically memoized/deduplicated by the framework. However, direct database queries using SDKs like  are not. If a page uses  and the main page component, identical database queries will execute twice per request, unnecessarily increasing database reads and TTFB.
+**Action:** When building Next.js Server Components with direct SDK database calls, wrap the data-fetching functions with  to ensure the query is executed only once per render pass.
+
+## 2024-05-25 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** In Next.js App Router, fetch() requests are automatically memoized/deduplicated by the framework. However, direct database queries using SDKs like firebase-admin are not. If a page uses generateMetadata and the main page component, identical database queries will execute twice per request, unnecessarily increasing database reads and TTFB.
+**Action:** When building Next.js Server Components with direct SDK database calls, wrap the data-fetching functions with React.cache() to ensure the query is executed only once per render pass.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,28 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProduct = cache(async (slugField: string, slug: string) => {
+    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot.empty ? null : snapshot.docs[0];
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProduct(slugField, slug);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -36,13 +41,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProduct(slugField, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
⚡ Bolt: Deduplicate metadata database queries

💡 What: Wrapped database query functions with `React.cache()` in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx`.

🎯 Why: In Next.js, `generateMetadata` and the page component execute in the same render pass. While native `fetch` requests are automatically deduplicated by Next.js, direct database queries (like `firebase-admin` Firestore lookups) are not. This caused identical queries to be executed twice per page load. Wrapping the query function in `React.cache()` ensures the query is executed only once per request.

📊 Impact: Reduces Firestore document reads by 50% for these pages and improves TTFB.

🔬 Measurement: By observing the network logs or database metrics, you should see exactly one document read instead of two when loading the `/[lang]/product/[slug]` or `/[lang]/[slug]` pages.

---
*PR created automatically by Jules for task [12821114904504767710](https://jules.google.com/task/12821114904504767710) started by @gokaiorg*