### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateProfile Server Action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,8 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+
+## 2024-05-22 - [Insecure Direct Object Reference (IDOR) in Server Actions]
+**Vulnerability:** A Next.js Server Action (`updateProfile` in `src/actions/auth.ts`) accepted a `uid` parameter to update a user's profile and password without explicitly verifying that the currently authenticated session belonged to that target `uid` or an admin user.
+**Learning:** Next.js global route middleware does not automatically protect or scope Server Actions. An authenticated attacker could pass arbitrary `uid` values to this server action and silently overwrite passwords or emails of any user, including admins.
+**Prevention:** Always implement explicit, manual authorization checks directly within sensitive Server Actions (e.g., `const session = await auth(); if (session?.user?.id !== targetUid && session?.user?.role !== "admin") return { error: "Unauthorized" };`) before performing any database mutations.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,14 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    const isOwner = session?.user?.id === uid;
+    const isAdmin = session?.user?.role?.toLowerCase() === "admin";
+
+    if (!session || (!isOwner && !isAdmin)) {
+        return { error: "Unauthorized: You do not have permission to modify this profile." };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Insecure Direct Object Reference (IDOR). The `updateProfile` Server Action took a `uid` as a parameter and directly passed it to Firebase Admin to update a user's details without validating if the current session actually belonged to that `uid`.
**🎯 Impact:** Any authenticated user (or unauthenticated, since the Server Action wasn't explicitly protected by middleware logic) could potentially send arbitrary `uid` values and forcefully change the password or name of *any* other user in the database, including admins, leading to complete account takeovers.
**🔧 Fix:** Imported `auth` from `@/auth` and implemented explicit runtime checks. The action now explicitly verifies that a session exists, and that the `session.user.id` matches the target `uid` being updated (or that the session has an admin role) before executing any Firebase Admin updates.
**✅ Verification:**
- Run `pnpm lint` and `pnpm build` (both passing successfully).
- To manually verify: Log in as a standard user, grab another user's `uid`, and attempt to invoke `updateProfile` with the other user's `uid`. It will now return `Unauthorized`.

---
*PR created automatically by Jules for task [4037534003563058033](https://jules.google.com/task/4037534003563058033) started by @gokaiorg*