### PR TITLE
🎨 Palette: [UX improvement] Use icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Password Visibility Toggle UX
+**Learning:** Hardcoding generic text like "Show" or "Hide" for a password toggle button creates cognitive load, takes up unnecessary visual space in compact form layouts, and introduces localization burdens.
+**Action:** Always replace plaintext labels on interactive UI toggles (like password visibility) with universally recognizable standard icons (e.g., `Eye` and `EyeOff`). Ensure `aria-hidden="true"` is set on the icon itself, while the parent `<button>` receives the localized `aria-label` for screen reader accessibility without double-announcement.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -129,11 +129,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 type="button"
                                 variant="ghost"
                                 size="sm"
-                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground"
+                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground cursor-pointer"
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff aria-hidden="true" className="h-4 w-4" /> : <Eye aria-hidden="true" className="h-4 w-4" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What**: 
Replaced the hardcoded text ("Show" and "Hide") inside the password visibility toggle button with standard `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why**: 
Relying on raw text for UI toggles increases cognitive load and creates unnecessary localization burdens. Universally recognized standard icons provide a cleaner, faster visual cue for users, freeing up space in the compact login form input fields while remaining highly intuitive.

**♿ Accessibility**: 
- The newly added icons receive `aria-hidden="true"` to prevent redundant screen reader announcements.
- The parent interactive element (`<Button>`) retains the explicit, dynamic `aria-label` which updates intelligently based on the `showPassword` state (e.g., "Show password" vs "Hide password").
- Ensured a clear `cursor-pointer` remains for mouse-based interactions.

---
*PR created automatically by Jules for task [9935980650091659199](https://jules.google.com/task/9935980650091659199) started by @gokaiorg*