### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-25 - Deduplicate Next.js data fetching with React.cache()
+**Learning:** In Next.js App Router, while native `fetch` requests are automatically deduplicated during a single request lifecycle (e.g., between `generateMetadata` and the page component), SDK calls like `firebase-admin` database queries are NOT. Without deduplication, these SDK calls will execute twice, hitting the database multiple times per page load.
+**Action:** When extracting database queries that are shared between `generateMetadata` and the page component, always import `cache` from `"react"` and wrap the data fetching function (e.g., `const getProduct = cache(async (id) => { ... })`). This memoizes the result for the duration of the request, eliminating duplicate database operations.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,24 +6,40 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
     
     if (snapshot.empty) {
+        return null;
+    }
+
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    return {
+        ...data,
+        id: doc.id,
+        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
+        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
+    } as Product;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const product = await getProductBySlug(lang, slug);
+
+    if (!product) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,21 +51,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const product = await getProductBySlug(lang, slug);
 
-    if (snapshot.empty) {
+    if (!product) {
         notFound();
     }
-
-    const doc = snapshot.docs[0];
-    const data = doc.data();
-    const product = {
-        ...data,
-        id: doc.id,
-        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
-        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
-    } as Product;
 
     const dict = await getDictionary(lang as Locale);
     const shopDict = dict.shop;


### PR DESCRIPTION
### 💡 What:
Wrapped shared Firestore queries in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` with `React.cache()`.

### 🎯 Why:
In Next.js App Router, while native `fetch` is automatically deduplicated, third-party SDK calls (like Firebase Admin queries) are not. Because the same database query was being executed in both `generateMetadata` and the page component, it resulted in two identical requests to Firestore per page load.

### 📊 Impact:
- Eliminates 1 redundant database query per page load on dynamic pages and product pages.
- Reduces Time To First Byte (TTFB) and cuts down on Firestore read operations.

### 🔬 Measurement:
Deploy or run the application locally. Navigate to a product page or dynamic page. Verify in the Firebase console or network logs that the database query for the page/product is only executed once instead of twice.

---
*PR created automatically by Jules for task [2883255631448146210](https://jules.google.com/task/2883255631448146210) started by @gokaiorg*