### PR TITLE
🎨 Palette: [UX improvement] Replace password toggle text with icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the plain text "Show"/"Hide" labels on the password visibility toggle in `LoginForm.tsx` with `Eye` and `EyeOff` icons.
🎯 **Why:** To improve visual UI polish and use universally recognized UX patterns for password toggles, making the interface cleaner and more intuitive.
♿ **Accessibility:** Added `aria-hidden="true"` to the icons so screen readers won't announce them redundantly. The parent `<Button>` retains its screen-reader-friendly `aria-label` which updates dynamically between "Show password" and "Hide password".

---
*PR created automatically by Jules for task [16050988506835733125](https://jules.google.com/task/16050988506835733125) started by @gokaiorg*