### PR TITLE
⚡ Bolt: deduplicate Firestore metadata queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-05-24 - [Deduplicate Firestore Metadata Queries]
+**Learning:** In Next.js App Router, wrapping Firestore calls (unlike native `fetch`) with `React.cache()` is critical. Otherwise, duplicated database calls across `generateMetadata` and the page component execute twice, doubling read operations and TTFB.
+**Action:** Always wrap redundant data-fetching queries, especially in SDKs like `firebase-admin` that lack native deduplication, in a `React.cache()` utility function.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { adminDb } from "@/lib/firebase-admin";
+import { cache } from "react";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
@@ -10,11 +11,12 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt: Use React.cache() to deduplicate Firestore queries between generateMetadata and the page component, cutting database reads in half
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,10 +12,15 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// ⚡ Bolt: Use React.cache() to deduplicate Firestore queries between generateMetadata and the page component, cutting database reads in half
+const getProductBySlug = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** Refactored `ProductPage` and `DynamicPage` routing paths to wrap their shared Firestore queries in `React.cache()`.
🎯 **Why:** In the Next.js App Router, while the native `fetch` API is automatically deduplicated, direct database calls via SDKs like `firebase-admin` are not. Because the same product/page data is queried in both `generateMetadata` and the default page export component, the database call was executing twice per request, leading to unnecessary database reads and slower Time To First Byte (TTFB).
📊 **Impact:** Cuts the number of database read operations in half for these routes, improving server response times and significantly reducing backend database load for initial page rendering.
🔬 **Measurement:** Verify by examining application profiling tools and network/server logs before and after the change; there will be exactly one outgoing database request to Firestore rather than two.

---
*PR created automatically by Jules for task [11560582904805859804](https://jules.google.com/task/11560582904805859804) started by @gokaiorg*