### PR TITLE
🎨 Palette: [UX improvement] Replace text with icons for password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What**: Replaced hardcoded "Show" and "Hide" text in the password visibility toggle of `LoginForm.tsx` with standard `Eye` and `EyeOff` icons from `lucide-react`.
🎯 **Why**: Using standard icons creates a more universally understood, cleaner, and intuitive UX, reducing visual clutter. It also circumvents potential localization issues with the hardcoded English text.
♿ **Accessibility**: Added `aria-hidden="true"` to the new `<Eye>` and `<EyeOff>` icons. Since the parent `<Button>` element already provides an explicit `aria-label` ("Show password" / "Hide password"), this prevents screen readers from redundantly announcing the icons, ensuring a smooth accessibility experience.

---
*PR created automatically by Jules for task [15790970606340017595](https://jules.google.com/task/15790970606340017595) started by @gokaiorg*