### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What**: Replaced the hardcoded "Show" and "Hide" text strings in the `LoginForm` password visibility toggle with standard `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why**: Using icons instead of raw text for password visibility is a standard, highly recognizable design pattern. It saves horizontal space, cleans up the form UI, and makes the interaction feel more polished and modern.

📸 **Before/After**: Visually verified using Playwright screenshots. The text has been replaced by the correct eye icons neatly aligned to the right.

♿ **Accessibility**: The new `lucide-react` icons were correctly equipped with `aria-hidden="true"`. This prevents screen readers from redundantly announcing the icons, allowing them to rely completely on the dynamically updating `aria-label` ("Show password" / "Hide password") already present on the parent interactive `<Button>`.

---
*PR created automatically by Jules for task [8777573229128623999](https://jules.google.com/task/8777573229128623999) started by @gokaiorg*