### PR TITLE
⚡ Bolt: Deduplicate Firestore database queries with React cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-05-26 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** Unlike native `fetch()` which is automatically deduplicated in Next.js App Router, direct database queries using the Firebase Admin SDK inside server components execute multiple times if called by both `generateMetadata` and the main page component.
+**Action:** Always wrap server-side database helper functions with `React.cache()` (e.g., `const getProduct = cache(async (slug) => { ... })`) to memoize the promise during a single request lifecycle, significantly improving TTFB and reducing database read costs.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,24 +6,38 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProduct = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
-    
     if (snapshot.empty) {
+        return null;
+    }
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    return {
+        ...data,
+        id: doc.id,
+        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
+        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
+    } as Product;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const product = await getProduct(lang, slug);
+
+    if (!product) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,21 +49,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const product = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!product) {
         notFound();
     }
-
-    const doc = snapshot.docs[0];
-    const data = doc.data();
-    const product = {
-        ...data,
-        id: doc.id,
-        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
-        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
-    } as Product;
 
     const dict = await getDictionary(lang as Locale);
     const shopDict = dict.shop;


### PR DESCRIPTION
💡 **What:** Extracted the duplicate Firestore read logic into reusable `getPage` and `getProduct` helper functions and wrapped them with `React.cache()`.
🎯 **Why:** In the Next.js App Router, while `fetch` calls are automatically deduplicated during the server render pass, direct database SDK calls (like Firebase Admin) are not. By directly calling `.get()` in both `generateMetadata` and the page component, the app was executing 2 identical database roundtrips per page load on Dynamic Routes.
📊 **Impact:** Reduces database reads by 50% for initial dynamic page loads (from 2 down to 1), significantly improving TTFB and cutting down Firestore billing costs.
🔬 **Measurement:** Can be verified by deploying, loading `/product/[slug]` or `/[slug]`, and inspecting the network waterfall or Firebase usage metrics.

---
*PR created automatically by Jules for task [16871021082736120998](https://jules.google.com/task/16871021082736120998) started by @gokaiorg*