### PR TITLE
⚡ Bolt: [Performance] Deduplicate Firestore queries in Server Components using React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2025-05-27 - Caching direct database calls in Next.js Server Components
+**Learning:** In Next.js App Router, while native `fetch` is automatically deduplicated, direct database calls (like those from the `firebase-admin` SDK) are not. If both `generateMetadata` and the main page component execute the same query, it results in a duplicated database call and unnecessary latency.
+**Action:** Always wrap non-fetch database query functions with `React.cache()` in Next.js Server Components. This ensures the query only executes once per request lifecycle, halving database read costs and improving load times.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,24 +6,31 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProduct = cache(async (slugField: string, slug: string) => {
+    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    const doc = snapshot.docs[0];
+    return { doc, data: doc.data() as Product };
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const productData = await getProduct(slugField, slug);
     
-    if (snapshot.empty) {
+    if (!productData) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
+    const product = productData.data;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -36,14 +43,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const productData = await getProduct(slugField, slug);
 
-    if (snapshot.empty) {
+    if (!productData) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
-    const data = doc.data();
+    const doc = productData.doc;
+    const data = productData.data as any;
     const product = {
         ...data,
         id: doc.id,


### PR DESCRIPTION
💡 **What:** Wrapped direct Firestore database queries inside `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`.

🎯 **Why:** In the Next.js App Router, functions like `generateMetadata` and the main Page component are executed sequentially for a single request. Next.js automatically deduplicates native `fetch()` calls, but direct database calls (like those from the `firebase-admin` SDK) execute independently. By using `React.cache()`, we ensure the query executes only once per request.

📊 **Impact:** Cuts the number of Firestore read operations in half for the `/product/[slug]` and `/[slug]` dynamic routes, significantly reducing latency and cost per page load.

🔬 **Measurement:** Can be verified by deploying and checking the Firestore billing dashboard for a reduction in read units, or by monitoring network request logs on the Next.js server.

---
*PR created automatically by Jules for task [14806955757684454542](https://jules.google.com/task/14806955757684454542) started by @gokaiorg*