### PR TITLE
🎨 Palette: Enhance password visibility toggle UX with standard icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the plain "Show"/"Hide" text labels in the password visibility toggle of the login form with standard `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** To improve the micro-UX and visual polish of the authentication forms. Icons are a more universally recognizable and space-efficient pattern for password toggles compared to text.

♿ **Accessibility:**
- Maintained the existing, descriptive `aria-label` on the interactive parent `<Button>` component.
- Added `aria-hidden="true"` to the new `Eye` and `EyeOff` icons to ensure screen readers do not read redundant or confusing information, providing a clean experience for all users.

---
*PR created automatically by Jules for task [7210088950548059859](https://jules.google.com/task/7210088950548059859) started by @gokaiorg*