### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-28 - Deduplicate Next.js generateMetadata Queries
+**Learning:** In Next.js App Router, `generateMetadata` and the default page component execute during the same request lifecycle. While native `fetch` deduplicates automatically, direct backend SDK queries (like `firebase-admin`'s `.get()`) do not, resulting in identical duplicate database queries per page load.
+**Action:** Always extract the shared data-fetching logic into a helper function wrapped in `React.cache()` (e.g., `const getProduct = cache(async (slug) => {...})`) to ensure the database query is only executed once per server request.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { Metadata } from "next";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
@@ -11,19 +12,24 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProduct = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return { doc: snapshot.docs[0], data: snapshot.docs[0].data() };
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const productInfo = await getProduct(lang, slug);
     
-    if (snapshot.empty) {
+    if (!productInfo) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
+    const product = productInfo.data as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,15 +41,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const productInfo = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!productInfo) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
-    const data = doc.data();
+    const { doc, data } = productInfo;
     const product = {
         ...data,
         id: doc.id,


### PR DESCRIPTION
💡 What:
Wrapped shared Firestore queries in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` with `React.cache()`.

🎯 Why:
In Next.js App Router, `generateMetadata` and the page component execute in the same request lifecycle. While native `fetch` requests are automatically deduplicated, direct third-party SDK calls (like `firebase-admin` queries) are not. This was causing two identical Firestore queries for every page load on product and dynamic pages.

📊 Impact:
Eliminates one redundant Firestore document read per page request, halving the database overhead for metadata-heavy dynamic pages and reducing the overall request duration.

🔬 Measurement:
Run the application and monitor the Network tab or Firebase Console reads. When loading a product page or a dynamic page, only one Firestore document read will occur instead of two.

---
*PR created automatically by Jules for task [3112336994425117236](https://jules.google.com/task/3112336994425117236) started by @gokaiorg*