### PR TITLE
⚡ Bolt: [Performance] Deduplicate Next.js metadata and page queries via React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-29 - [Next.js App Router Database Query Deduplication]
+**Learning:** In Next.js App Router, while the native `fetch` API is automatically deduplicated, direct database calls using SDKs (like `firebase-admin` in this project) are not. Calling the same query in both `generateMetadata` and the page component results in two identical database queries executing per request, significantly increasing TTFB and database load.
+**Action:** Always wrap non-fetch database query functions inside dynamically rendered Next.js Server Components with React's `cache()` API (`import { cache } from "react"`). This ensures the query result is memoized and only executes once per server request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,29 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProduct = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProduct(lang, slug);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +41,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
### 💡 What
Wrapped `firebase-admin` database queries within dynamically generated Next.js pages (`product/[slug]` and `[slug]`) with React's `cache()` function.

### 🎯 Why
In the Next.js App Router, while native `fetch` requests are automatically deduplicated, direct server-side database calls (like those via `firebase-admin`) are not. Because the exact same query was being called in both `generateMetadata` and the default page component to fetch the document for SEO and rendering, the server was executing two identical database reads per page request, increasing both TTFB and database costs.

### 📊 Impact
- Reduces database read operations by exactly 50% for product pages and dynamic text pages.
- Improves Server-Side Rendering (SSR) Time To First Byte (TTFB) by avoiding a redundant network round-trip to Firestore.

### 🔬 Measurement
Verify the improvement by observing server console logs or Firebase usage metrics. A single page load of a product or dynamic page will now only increment Firestore read counts by 1 instead of 2. The Next.js dev server will also process the request faster.

---
*PR created automatically by Jules for task [11473038769686523092](https://jules.google.com/task/11473038769686523092) started by @gokaiorg*