### PR TITLE
🎨 Palette: [UX] Replace password visibility text with recognizable icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
### 💡 What
Replaced the hardcoded text ("Show" / "Hide") in the login form's password toggle button with standardized `Eye` and `EyeOff` icons from the `lucide-react` library.

### 🎯 Why
Recognizable icons are standard practice for password visibility toggles. Text can feel clunky in compact input fields and requires translation, whereas the eye icon is a universal UX pattern that users instantly understand, creating a smoother and more polished interaction.

### ♿ Accessibility
The icons have been marked with `aria-hidden="true"` to prevent redundant screen reader announcements, since the parent `<Button>` element already explicitly declares its action via the dynamic `aria-label="Show password"` / `"Hide password"` attribute. This ensures keyboard and screen reader accessibility remains intact.

### 📸 Before/After
*(Visuals verified via internal Playwright testing - see verification screenshot in PR thread)*

---
*PR created automatically by Jules for task [2770040393064331654](https://jules.google.com/task/2770040393064331654) started by @gokaiorg*