### PR TITLE
⚡ Bolt: cache firebase queries to halve database reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-30 - Firebase Admin Query Deduplication in Next.js App Router
+**Learning:** In Next.js App Router, while native `fetch` is automatically deduplicated across `generateMetadata` and page components, direct database queries using the `firebase-admin` SDK are not. This causes the same Firestore query to execute twice per request lifecycle on dynamic routes (e.g., `/product/[slug]`).
+**Action:** Always wrap non-fetch database query functions with `React.cache()` when the data is needed in multiple server-side contexts during the same request to halve database reads and improve response times.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
+import { cache } from "react";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
@@ -11,10 +12,14 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProduct = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** Wrapped direct `firebase-admin` Firestore queries in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` with `React.cache()`.
🎯 **Why:** In the Next.js App Router, `generateMetadata` and the default page component execute independently. While Next.js automatically deduplicates native `fetch` requests, it does not deduplicate direct SDK calls like those from `firebase-admin`. This was causing identical Firestore database queries to execute twice per request.
📊 **Impact:** Halves the number of database reads for the dynamic product and page routes, directly improving Time To First Byte (TTFB) and reducing backend load/costs.
🔬 **Measurement:** This can be verified by observing the Firebase console read count or logging the execution of the query function during a page load; it will now only execute once.

---
*PR created automatically by Jules for task [6271920472993913009](https://jules.google.com/task/6271920472993913009) started by @gokaiorg*