### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with standard icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,3 @@
+1. Modify `src/components/LoginForm.tsx` to replace the "Show" / "Hide" text for the password visibility toggle with `Eye` and `EyeOff` icons from `lucide-react`.
+2. Ensure the icons have `aria-hidden="true"` and the button has a proper `aria-label`, as well as fixing any size constraints.
+3. Run verification (lint, build).


### PR DESCRIPTION
### 💡 What\nReplaced the "Show" and "Hide" text for the password visibility toggle in `src/components/LoginForm.tsx` with standard `Eye` and `EyeOff` icons from `lucide-react`.\n\n### 🎯 Why\nUsing standard icons for password visibility is a ubiquitous UX pattern that users instantly recognize. It saves horizontal space and creates a cleaner, more modern aesthetic compared to raw text.\n\n### ♿ Accessibility\nMaintained the dynamic `aria-label` on the parent `<Button>` and added `aria-hidden="true"` to the newly introduced icons. This ensures screen readers announce the button's purpose clearly without needlessly attempting to interpret the SVG elements.

---
*PR created automatically by Jules for task [16271303619190348797](https://jules.google.com/task/16271303619190348797) started by @gokaiorg*