### PR TITLE
⚡ Bolt: [Performance] Deduplicate database queries in Next.js Server Components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2025-05-31 - Deduplicate identical database queries in Next.js Server Components with React.cache()
+**Learning:** In Next.js App Router, the exact same database call (like fetching a page or product by ID/slug using `firebase-admin`) made inside both `generateMetadata` and the default page component will execute twice per request. While Next.js automatically deduplicates native `fetch` requests, it does not deduplicate direct database SDK calls.
+**Action:** Always wrap these duplicated non-fetch database query functions with `React.cache()` (e.g., `const getProduct = cache(async (id) => { ... })`). This ensures the expensive backend query only executes once per request lifecycle, reducing database load and improving Server-Side Rendering response times.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,21 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const snapshot = await getProductBySlug(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 What: Wrapped `getPage` and product fetches in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` with `React.cache()`.
🎯 Why: In Next.js App Router, direct database SDK calls (like Firebase) executed in both `generateMetadata` and the default page component run twice per user request. `fetch` is auto-deduplicated, but SDK queries are not.
📊 Impact: Halves the number of database reads for dynamic pages and product pages, directly reducing Firebase billing and improving Server-Side Rendering (SSR) Time-To-First-Byte (TTFB).
🔬 Measurement: Verify by checking network traces or server logs; the database query should now only fire once per page load.

---
*PR created automatically by Jules for task [8139268069621435423](https://jules.google.com/task/8139268069621435423) started by @gokaiorg*