### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateProfile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+## 2024-05-31 - IDOR in Profile Update Action
+**Vulnerability:** Insecure Direct Object Reference (IDOR) in `updateProfile` server action. Any user could update any other user's profile, including their password, by providing an arbitrary `uid`.
+**Learning:** Server actions inherently bypass layout/route level middleware protection. They must independently establish authentication and authorization.
+**Prevention:** Always verify that the authenticated session ID (`session?.user?.id`) matches the target resource ID parameter in user-specific mutations within Server Actions to prevent IDOR, unless the user possesses an explicit admin role.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { auth } from "@/auth";
 import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
@@ -56,6 +57,16 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    if (!session || !session.user) {
+        return { error: "Unauthorized" };
+    }
+
+    const userRole = (session.user.role || "").toLowerCase();
+    if (session.user.id !== uid && userRole !== "admin") {
+        return { error: "Forbidden" };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** IDOR in updateProfile server action where any user could update any profile.
**Impact:** Allows arbitrary users to change the name, email, or password of any account by passing an arbitrary `uid`.
**Fix:** Added session authorization check against the provided user ID (`session.user.id === uid`) to prevent unauthorized modification. Allowed admins to still edit arbitrary profiles.
**Verification:** Tested with standard verification commands (`pnpm run lint` and `pnpm run build`).

---
*PR created automatically by Jules for task [7595638246138806608](https://jules.google.com/task/7595638246138806608) started by @gokaiorg*