### PR TITLE
🎨 Palette: [UX improvement] Use intuitive icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2025-05-31 - Password Visibility Toggle UX
+**Learning:** Text labels like "Show" or "Hide" on small password toggle buttons can feel clunky and inconsistent with modern UI patterns, taking up unnecessary space in the input field. Using universally recognized icons (like the open/closed eye) creates a cleaner aesthetic and aligns better with standard icon-only button patterns in design systems like shadcn.
+**Action:** When implementing password visibility toggles, prefer standard `Eye` and `EyeOff` icons over raw text labels. Ensure the parent button includes an explicit `aria-label` (e.g., "Show password") and the icons use `aria-hidden="true"` to maintain accessibility while improving visual polish.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -128,12 +128,16 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                             <Button
                                 type="button"
                                 variant="ghost"
-                                size="sm"
-                                className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground"
+                                size="icon"
+                                className="absolute right-0 top-0 h-full hover:bg-transparent text-muted-foreground hover:text-foreground"
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
### 💡 What
Replaced the "Show" and "Hide" text labels in the `LoginForm` password visibility toggle with standard `Eye` and `EyeOff` icons from `lucide-react`. Updated the button to use the `size="icon"` variant for cleaner proportions.

### 🎯 Why
Text labels in small interactive toggle buttons can feel clunky and inconsistent with modern UI patterns. Using universally recognized icons creates a cleaner aesthetic within the input field and aligns perfectly with standard icon-only button patterns in the design system.

### 📸 Before/After
**Before:** Text button reading "Show" or "Hide" inside the password field.
**After:** A visually clean icon button showing an open eye (to show) or a closed eye (to hide).

### ♿ Accessibility
Maintained the explicit `aria-label` ("Show password" / "Hide password") on the parent `<Button>` element to ensure full keyboard and screen reader accessibility. Added `aria-hidden="true"` to the new `<Eye>` and `<EyeOff>` icons to prevent screen readers from redundantly announcing the icon names.

---
*PR created automatically by Jules for task [7207735976446230778](https://jules.google.com/task/7207735976446230778) started by @gokaiorg*