### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What**: Replaced the "Show"/"Hide" text strings in the password visibility toggle button with `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why**: Using universally recognized icons for password visibility toggles is a standard UX pattern that reduces visual clutter in forms, prevents text shifting when toggling states, and provides a more modern look and feel.

📸 **Before/After**: See the verification screenshot. The text label inside the input field was removed in favor of a sleek eye icon that toggles when clicked.

♿ **Accessibility**: Maintained full accessibility by:
- Keeping the existing dynamic `aria-label` on the parent `<Button>`.
- Adding `aria-hidden="true"` to both SVG icons so screen readers do not redundantly announce them.
- Ensuring the toggle is still fully keyboard operable since it remains a standard `<Button>`.

---
*PR created automatically by Jules for task [14461949364236011954](https://jules.google.com/task/14461949364236011954) started by @gokaiorg*