### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Next.js Server Component Database Queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,9 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-06-01 - Deduplicate Next.js Server Component Database Queries
+**Learning:** In Next.js App Router, direct database calls (like  queries) executed in both  and the page component run twice per request lifecycle because they are not automatically deduplicated like native .
+**Action:** Always wrap these non-fetch database query functions with  to ensure they only execute once per request, halving the database reads for those specific page loads.
+## 2024-06-01 - Deduplicate Next.js Server Component Database Queries
+**Learning:** In Next.js App Router, direct database calls (like `firebase-admin` queries) executed in both `generateMetadata` and the page component run twice per request lifecycle because they are not automatically deduplicated like native `fetch()`.
+**Action:** Always wrap these non-fetch database query functions with `React.cache()` to ensure they only execute once per request, halving the database reads for those specific page loads.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What**: Wrapped Firebase Admin database queries in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`.
🎯 **Why**: In Next.js App Router, direct database queries executed in both `generateMetadata` and the page rendering component run twice per request lifecycle because they aren't automatically deduplicated like native `fetch()` calls. 
📊 **Impact**: Halves the number of database reads for these page loads, improving Time To First Byte (TTFB) and reducing database cost/load.
🔬 **Measurement**: Inspect network traffic or database logs to confirm that the `adminDb.collection()` queries are only executed once per page load instead of twice.

---
*PR created automatically by Jules for task [15305436910921604272](https://jules.google.com/task/15305436910921604272) started by @gokaiorg*