### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with standard icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2024-05-18 - Standardize Password Visibility Toggle UX
+**Learning:** Raw text like "Show" / "Hide" for password visibility toggles is a suboptimal UX pattern that can be replaced with standard recognizable icons (`Eye` / `EyeOff`) from `lucide-react` for better visual polish. When replacing text with icons, it is critical to retain the parent button's `aria-label` for screen reader users and add `aria-hidden="true"` to the new SVG icons to prevent redundant or confusing screen reader announcements.
+**Action:** When implementing or fixing interactive toggles, always default to standard recognizable icons equipped with `aria-hidden="true"` and an explicit `aria-label` on the parent interactive element.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What**: Replaced the "Show" and "Hide" raw text in the password visibility toggle of the `LoginForm` component with standard recognizable `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why**: Using universally recognized icons for common interactions like toggling password visibility provides better visual polish, saves space, and creates a more intuitive interface compared to raw text.

**♿ Accessibility**: Maintained the existing explicit `aria-label` ("Show password" / "Hide password") on the parent `<Button>` for screen reader users. Added `aria-hidden="true"` to the newly introduced SVG icons to prevent redundant or confusing screen reader announcements, fully conforming to the project's accessibility guidelines for interactive toggles.

---
*PR created automatically by Jules for task [15568228764115767012](https://jules.google.com/task/15568228764115767012) started by @gokaiorg*