### PR TITLE
🎨 Palette: [UX improvement] Replace password visibility text with icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-05-15 - Testing Isolated Components for UI Verification
+**Learning:** When performing frontend verification on complex apps (like those requiring Firebase Admin or next-auth in the root layout), testing specific components (like `LoginForm`) in the main route will fail due to missing environment variables and backend errors.
+**Action:** Instead of fixing the complex root layout or mocking entire databases for a simple visual check, create a temporary test route (e.g., `src/app/[lang]/test-login/page.tsx`) that renders *only* the isolated component with mocked props and necessary providers (e.g., `<ThemeProvider>`). Clean up these artifacts before submitting.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced the raw text "Show" and "Hide" with standard `Eye` and `EyeOff` icons for the password visibility toggle in `LoginForm`.
**🎯 Why:** Improves visual polish and cognitive recognition of the password toggle, aligning with modern design patterns and saving horizontal space in the form.
**📸 Before/After:** The text button now displays a clean icon.
**♿ Accessibility:** Maintained the existing `aria-label` on the button to ensure screen reader context ("Show password" / "Hide password") and added `aria-hidden="true"` to the `Eye` and `EyeOff` icons to prevent redundant or confusing screen reader announcements.

---
*PR created automatically by Jules for task [6758845992577592385](https://jules.google.com/task/6758845992577592385) started by @gokaiorg*