### PR TITLE
🎨 Palette: [UX improvement] Replace password text toggle with accessible icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2026-06-04 - Password Toggle Accessibility
+**Learning:** Raw text like 'Show' and 'Hide' inside a password visibility toggle button is less globally recognizable than standard `Eye` and `EyeOff` icons, which visually convey the toggle state more clearly. When adding icons to an existing button that has a dynamic `aria-label`, it is essential to include `aria-hidden="true"` on the icons to prevent screen readers from reading both the text label and an implied icon description.
+**Action:** Replace plain text inside visibility toggle buttons with appropriate standard icons, and always set `aria-hidden="true"` on the SVG when an explicit `aria-label` already describes the button's action on the parent.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -90,6 +90,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 id="name"
                                 name="name"
                                 type="text"
+                                autoComplete="name"
                                 placeholder="John Doe"
                                 required
                                 value={name}
@@ -133,7 +134,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Replaced the "Show"/"Hide" text in the password visibility toggle button with `Eye` and `EyeOff` icons from `lucide-react`. Also added `autoComplete="name"` to the name input field.
🎯 Why: Text labels are language-dependent and visually less intuitive. Standard icons provide a much more universally recognizable visual cue for revealing or hiding passwords. Adding the `autoComplete` attribute improves the form filling experience.
♿ Accessibility: The parent button already dynamically updates its `aria-label` based on state ("Show password" / "Hide password"). Added `aria-hidden="true"` to the newly introduced icons to avoid redundant screen reader announcements. The added `autoComplete` attribute to the name input helps assistive technologies accurately categorize the field.

---
*PR created automatically by Jules for task [5364189622795019843](https://jules.google.com/task/5364189622795019843) started by @gokaiorg*