### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in profile updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,8 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+
+## 2026-06-04 - Insecure Direct Object Reference (IDOR) in Next.js Server Actions
+**Vulnerability:** Critical IDOR in the `/updateProfile` server action. The `updateProfile` Server Action in `src/actions/auth.ts` lacked explicit authorization checks. It blindly accepted a `uid` argument to update the profile without validating that the user performing the request owned the account.
+**Learning:** In Next.js App Router, Server Actions do not implicitly bind the context of the requested parameter (e.g., `uid`) to the current user's session.
+**Prevention:** Every Server Action performing user-specific updates must explicitly compare the authenticated session's user ID with the target resource's ID (e.g., `if (session?.user?.id !== uid) return { error: "Forbidden" };`), unless an explicit override mechanism (e.g. an admin role) applies.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,15 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    if (!session?.user?.id) {
+        return { error: "Unauthorized" };
+    }
+    const userRole = (session.user.role || "").toLowerCase();
+    if (session.user.id !== uid && userRole !== "admin") {
+        return { error: "Forbidden: You cannot update another user's profile." };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `updateProfile` server action in `src/actions/auth.ts` lacked explicit authorization checks. It blindly accepted a `uid` argument to update any profile without verifying if the user performing the request owned the account.
🎯 Impact: This allowed any user to modify another user's profile details or password by spoofing the `uid` parameter in the server action.
🔧 Fix: Added a session check using `auth()` to ensure the `session.user.id` strictly matches the `uid`, or the user holds an `admin` role, before proceeding with the Firestore updates.
✅ Verification: Ran `pnpm build` and `pnpm lint` successfully. Verified logic locally.

---
*PR created automatically by Jules for task [3091416822677190751](https://jules.google.com/task/3091416822677190751) started by @gokaiorg*