### PR TITLE
🎨 Palette: [UX improvement] Add icon toggle for password visibility

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
## 💡 What
Replaced the plain text "Show"/"Hide" toggle on the password field with standard, recognizable `Eye` and `EyeOff` icons from `lucide-react`.

## 🎯 Why
Iconography is generally quicker to process than text for common toggles like password visibility, creating a more polished and intuitive interaction pattern.

## ♿ Accessibility
- Added `aria-hidden="true"` to the new `<Eye>` and `<EyeOff>` icons.
- Retained the explicit `aria-label={showPassword ? "Hide password" : "Show password"}` on the parent `<Button>`. 
- This combination ensures screen readers accurately announce the button's action without reading out confusing or redundant icon names.

---
*PR created automatically by Jules for task [7551498174906867579](https://jules.google.com/task/7551498174906867579) started by @gokaiorg*