### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries with React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-06-05 - Deduplicate Next.js Server Component Database Queries
+**Learning:** In Next.js App Router, if a dynamic route fetches the same data in both `generateMetadata` and the main page component (e.g., using `firebase-admin` to fetch a document), the database query will execute twice per request. While Next.js automatically deduplicates native `fetch()` calls, it does not deduplicate direct SDK calls like Firestore.
+**Action:** Always refactor the shared direct database call into a separate function and wrap it with `React.cache()` (imported from `react`). This guarantees the expensive database query is only executed once per incoming server request, reducing latency and database reads.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,14 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt Performance Optimization:
+// React's `cache` deduplicates this Firestore query across `generateMetadata` and the main `DynamicPage` render.
+// This prevents identical queries from executing twice during a single server request, reducing TTFB and database costs.
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,23 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// ⚡ Bolt Performance Optimization:
+// React's `cache` deduplicates this Firestore query across `generateMetadata` and the main `ProductPage` render.
+// This prevents identical queries from executing twice during a single server request, reducing TTFB and database costs.
+const getProduct = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 What: Wrapped Firestore database queries within `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` using `React.cache()`.
🎯 Why: In Next.js App Router, while native `fetch` calls are automatically deduplicated, direct database SDK calls (like `firebase-admin`) are not. Because the exact same document is required by both `generateMetadata` and the main `Page` component, the database was executing identical queries twice per user request. 
📊 Impact: Eliminates duplicate Firestore reads per dynamic page request. Reduces database egress costs by ~50% for these routes and improves Time To First Byte (TTFB).
🔬 Measurement: Verify by adding console logs inside the cached function and loading the page; the log should only appear once despite being called by both the metadata and page functions.

---
*PR created automatically by Jules for task [11107919451354512290](https://jules.google.com/task/11107919451354512290) started by @gokaiorg*