### PR TITLE
⚡ Bolt: Optimize duplicate Firestore queries in metadata using React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-25 - React.cache for Server Component Data Fetching Deduplication
+**Learning:** In Next.js App Router, `generateMetadata` and the default page component execute independently. While native `fetch()` calls are automatically deduplicated by Next.js, direct database queries (like `firebase-admin` SDK calls via `adminDb.collection`) are not. This causes the exact same database query to run twice per request, doubling database reads and degrading server response times.
+**Action:** Always extract direct server-side database queries into a helper function and wrap that function with `React.cache()`. This ensures the database query is executed only once per request lifecycle, and its result is shared across `generateMetadata` and the main component.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,13 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt: Deduplicate identical Firestore queries across generateMetadata and the page component during SSR using React.cache().
+// Impact: Reduces database reads for the dynamic page route by 50% per request.
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,35 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+// ⚡ Bolt: Deduplicate identical Firestore queries across generateMetadata and the Product page component during SSR using React.cache().
+// Impact: Reduces database reads for the product route by 50% per request.
+const getProductBySlug = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
     
     if (snapshot.empty) {
+        return null;
+    }
+
+    return snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProductBySlug(lang, slug);
+
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +47,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(lang, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
**💡 What:** 
Extracted duplicate `adminDb` Firestore queries from `generateMetadata` and default exported page components into helper functions, wrapping them in `React.cache()` (`src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx`). Added comments explaining the performance optimizations.

**🎯 Why:** 
In Next.js App Router, `generateMetadata` and the page component execute independently. While native `fetch` calls are automatically deduplicated by Next.js, direct SDK calls like `firebase-admin` Firestore queries are not. This was causing the exact same document to be queried twice per request, doubling database reads and latency. Wrapping the database call in `React.cache()` shares the result across the request lifecycle.

**📊 Impact:** 
Reduces Firestore database reads and network roundtrips by 50% for dynamic page requests (`/product/[slug]` and `/[slug]`), substantially improving TTFB and cutting backend database costs.

**🔬 Measurement:** 
Verify the improvement by profiling network requests/TTFB in the browser DevTools, or by inspecting Firestore database read metrics before and after the change.

---
*PR created automatically by Jules for task [16090533565035265816](https://jules.google.com/task/16090533565035265816) started by @gokaiorg*