### PR TITLE
🎨 Palette: [UX] Use icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Interactive Toggles Should Use Icons, Not Text
+**Learning:** For interactive toggles (like password visibility), raw text labels ("Show" / "Hide") take up unnecessary horizontal space and require translation. Replacing them with standard recognizable icons (like `Eye` and `EyeOff`) improves the UI's cleanliness and universality.
+**Action:** Always replace text-based interactive toggles with standard icons equipped with `aria-hidden="true"`, ensuring the parent interactive element retains the explicit `aria-label` for screen reader accessibility.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the plain "Show" / "Hide" text in the password visibility toggle of the `LoginForm` with standard `Eye` and `EyeOff` icons.
🎯 **Why:** Text toggles take up unnecessary horizontal space and require localization. Using universally recognized icons improves the UI's cleanliness, provides a more standard interaction pattern, and makes the visual element language-agnostic.
📸 **Before/After:** The button now cleanly shows an Eye or EyeOff icon instead of text.
♿ **Accessibility:** The new decorative icons are properly hidden from screen readers using `aria-hidden="true"`, as the parent `<Button>` already maintains a dynamic `aria-label` ("Show password" / "Hide password") for full keyboard and screen reader accessibility.

---
*PR created automatically by Jules for task [5960801491399789387](https://jules.google.com/task/5960801491399789387) started by @gokaiorg*