### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with standard icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Interactive Toggles Should Use Recognizable Icons
+**Learning:** Raw text labels (like "Show" / "Hide") inside interactive toggles can reduce internationalization flexibility and UI polish.
+**Action:** Replace plain text toggle labels with recognizable icons (e.g., Eye / EyeOff from `lucide-react`). Add `aria-hidden="true"` to the icons and ensure the parent interactive element (like a `<Button>`) maintains an explicit `aria-label` for screen reader accessibility.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the plain text "Show" / "Hide" in the password visibility toggle of the `LoginForm` with standard `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** Replacing text with widely recognized icons improves the visual polish of the application, makes the interface more intuitive, and removes the need to localize "Show" and "Hide" strings. 

♿ **Accessibility:** Added `aria-hidden="true"` to the newly introduced icons. This ensures screen readers do not announce the SVG elements redundantly, as the parent `<Button>` correctly handles the announcement via its dynamic `aria-label` attribute (`aria-label={showPassword ? "Hide password" : "Show password"}`).

---
*PR created automatically by Jules for task [6275699043150021466](https://jules.google.com/task/6275699043150021466) started by @gokaiorg*