### PR TITLE
⚡ Bolt: Deduplicate Firestore queries on dynamic pages

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,13 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt: Wrapped getPage in React.cache to memoize the result.
+// Impact: Reduces database reads by 50% for dynamic pages because generateMetadata and the page component use the same data.
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,31 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+// ⚡ Bolt: Wrapped getProduct in React.cache to memoize the result.
+// Impact: Eliminates duplicate Firestore queries per page load, reducing database reads by 50% for product pages.
+const getProduct = cache(async (slug: string, lang: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProduct(slug, lang);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +43,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProduct(slug, lang);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
### 💡 What
Wrapped independent Firestore database lookups (`getPage` and `getProduct`) with `React.cache()` in Next.js Server Components.

### 🎯 Why
In Next.js App Router, `generateMetadata` and the primary page component both execute independently. When relying on external database/ORM tools like `firebase-admin` (which, unlike native `fetch`, are not automatically deduplicated by Next.js), this results in the exact same database query being executed twice on every single page load.

### 📊 Impact
Reduces database reads by 50% for dynamic shop and product pages, significantly improving backend performance and lowering Firestore billing costs.

### 🔬 Measurement
Check the Next.js server trace or Firestore read metrics; there should now only be 1 read per page load for the respective documents instead of 2.

---
*PR created automatically by Jules for task [4328181756279311277](https://jules.google.com/task/4328181756279311277) started by @gokaiorg*