### PR TITLE
⚡ Bolt: Deduplicate duplicate Firestore queries with React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-24 - Prevent duplicate Firestore queries in Next.js
+**Learning:** In Next.js App Router, `generateMetadata` and the default page component execute independently. While the native `fetch()` API is automatically deduplicated by Next.js, direct database queries (such as those using the Firebase Admin SDK) are not. This means querying for a document by slug will cause two identical network requests to Firestore per page load.
+**Action:** Always extract direct database lookups into a helper function and wrap it with `React.cache()` (imported from `"react"`) to ensure the backend executes the query only once per request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,19 +12,27 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProduct = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
     
-    if (snapshot.empty) {
+    if (snapshot.empty) return null;
+
+    const doc = snapshot.docs[0];
+    return { doc, data: doc.data() };
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const result = await getProduct(lang, slug);
+
+    if (!result) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
+    const product = result.data as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,15 +44,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const result = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!result) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
-    const data = doc.data();
+    const { doc, data } = result;
     const product = {
         ...data,
         id: doc.id,


### PR DESCRIPTION
💡 **What**: Extracted direct Firebase Admin SDK queries into helper functions and wrapped them with `React.cache()` in both `ProductPage` (`src/app/[lang]/(shop)/product/[slug]/page.tsx`) and the general dynamic page (`src/app/[lang]/(shop)/[slug]/page.tsx`).

🎯 **Why**: In Next.js App Router, `generateMetadata` and the default page component execute independently. While the native `fetch()` API is automatically deduplicated, direct server-side database lookups (like `firebase-admin`) are not. This was causing duplicate identical reads to Firestore per page load.

📊 **Impact**: Reduces Firestore reads by exactly 50% for these pages and improves TTFB by eliminating an entire unnecessary database roundtrip on the server.

🔬 **Measurement**: Verified by checking network traces/Firestore metrics. A single page load now only triggers a single query for the underlying document data. Tested build successfully (`pnpm build`).

---
*PR created automatically by Jules for task [1283409100459656541](https://jules.google.com/task/1283409100459656541) started by @gokaiorg*