### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-06-09 - Password Visibility Toggle
+**Learning:** For interactive icon toggles, raw text (like "Show"/"Hide") should be replaced with universally recognized icons (like `Eye`/`EyeOff` from lucide-react) to improve visual UX, provided they are paired with `aria-hidden="true"` and an explicit `aria-label` on the parent `<Button>` to ensure accessibility is maintained for screen readers.
+**Action:** When updating form components, check if visibility toggles use raw text and upgrade them to use standard lucide-react icons while preserving existing ARIA labels.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**🎨 Palette: [UX improvement] Enhance password visibility toggle**

**💡 What:** Replaced the raw text "Show" and "Hide" in the password input visibility toggle button with standard `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why:** Text labels like "Show" can clutter the input field on smaller screens or conflict with localization if not translated. Universally recognized icons provide a cleaner, more intuitive user experience for interacting with sensitive inputs.

**📸 Before/After:** 
- Before: Text reading "Show" or "Hide" inside the button.
- After: Standard Eye and EyeOff icons inside the button. 
*(See Playwright videos/screenshots in the trace).*

**♿ Accessibility:** The parent `<Button>` element already contained a dynamic `aria-label` ("Show password" / "Hide password"). I added `aria-hidden="true"` to the new `<Eye>` and `<EyeOff>` SVG icons to ensure screen readers don't double-read or get confused by the SVGs, maintaining the existing high standard of accessibility while improving the visual UX.

---
*PR created automatically by Jules for task [17814404910281297878](https://jules.google.com/task/17814404910281297878) started by @gokaiorg*