### PR TITLE
🎨 Palette: Replace text with icons for password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced the raw text labels "Show" and "Hide" in the password visibility toggle of the login form with standard `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why:** Standard icons are a universally recognized UX pattern for password visibility toggles. This makes the interface cleaner, more intuitive, and quicker to parse visually compared to raw text labels.

**♿ Accessibility:** The new icons are marked with `aria-hidden="true"`. The parent button already dynamically updates its `aria-label` between "Show password" and "Hide password", so screen reader users will continue to hear clear, descriptive text without any redundant or confusing "Eye" icon announcements.

---
*PR created automatically by Jules for task [9778538659379872361](https://jules.google.com/task/9778538659379872361) started by @gokaiorg*