### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix authorization bypass in profile update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+## 2024-06-11 - Missing Authorization in Server Actions (IDOR)
+**Vulnerability:** The `updateProfile` server action was missing explicit authorization checks, allowing any user to pass arbitrary `uid` parameters and update other users' profile data (including passwords), resulting in a critical IDOR vulnerability.
+**Learning:** Server Actions bypass standard Next.js route-level middleware protection (`middleware.ts`). Assuming a route is protected does not mean its imported server actions are implicitly protected.
+**Prevention:** Always implement explicit, independent session authorization checks directly within sensitive server actions before processing data mutations. Verify that the authenticated session ID matches the target resource ID parameter unless an explicit admin role check is performed.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,12 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+
+    if (session?.user?.id !== uid && session?.user?.role?.toLowerCase() !== "admin") {
+        return { error: "Unauthorized" };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `updateProfile` server action accepted an arbitrary `uid` without any authorization checks. This allowed unauthenticated or unauthorized users to update any other user's profile data, including resetting their password (an Insecure Direct Object Reference (IDOR) vulnerability).
🎯 **Impact**: Total account takeover. An attacker could reset any user's password and assume control of their account by bypassing authorization.
🔧 **Fix**: Added explicit session validation inside `updateProfile` using `auth()`. The function now verifies that the caller is either updating their own profile (`session.user.id === uid`) or possesses an 'admin' role, returning `{ error: "Unauthorized" }` otherwise.
✅ **Verification**: Run `pnpm test` and `pnpm lint`. Attempting to call `updateProfile` with another user's `uid` when not an admin will securely fail.

---
*PR created automatically by Jules for task [9351731368902921456](https://jules.google.com/task/9351731368902921456) started by @gokaiorg*