### PR TITLE
🎨 Palette: [UX improvement] Add clear Eye icons to password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
### 💡 What
Replaced the plain text "Show"/"Hide" labels on the password visibility toggle button in `LoginForm` with standard `Eye` and `EyeOff` icons from `lucide-react`.

### 🎯 Why
A standard visual icon (eye) is a much more universally recognized pattern for toggling password visibility compared to raw text labels, making the interface more intuitive and professional.

### 📸 Before/After
**Before:** The toggle button just showed the text "Show" or "Hide" on the right side of the password field.
**After:** The toggle button now shows a clear, modern `Eye` or `EyeOff` icon.

### ♿ Accessibility
Preserved the existing `aria-label` attribute on the parent `<Button>` to ensure screen readers properly announce "Show password" or "Hide password". I also explicitly added `aria-hidden="true"` to the new SVG icons themselves to prevent screen readers from announcing redundant or confusing SVG-related tags.

---
*PR created automatically by Jules for task [11790508529601222808](https://jules.google.com/task/11790508529601222808) started by @gokaiorg*