### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate metadata Firestore queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2025-06-11 - Deduplicate identical database calls using React.cache()
+**Learning:** In Next.js App Router, it's common to need the same data in both `generateMetadata` and the page component (e.g., fetching a product from Firestore). While native `fetch()` is automatically deduplicated, direct database calls (like `adminDb.collection(...).get()`) are not, leading to duplicate queries and doubled TTFB. Firestore `QuerySnapshot` promises are perfectly serializable and safe to cache during a server request.
+**Action:** Always wrap these non-fetch database query functions with `React.cache()` to ensure they only execute once per request lifecycle, halving the database read operations and improving server-side response times.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,10 +12,15 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (slug: string, lang: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const snapshot = await getProductBySlug(slug, lang);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slug, lang);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** 
Wrapped Firebase Admin SDK queries in `React.cache()` for dynamic routes (`product/[slug]` and `[slug]`).

🎯 **Why:** 
In Next.js App Router, data is fetched in `generateMetadata` for SEO and again in the page component for rendering. While native `fetch` requests are automatically deduplicated by Next.js, direct database SDK calls (like `adminDb.collection(...).get()`) are not. This was causing double the necessary database reads for every page load.

📊 **Impact:** 
- Cuts database read operations by 50% for dynamic pages.
- Improves Time To First Byte (TTFB) by avoiding duplicate network requests to Firestore.

🔬 **Measurement:** 
Verify by checking Firestore usage logs or adding a `console.log` inside the `getPage` or `getProductBySlug` functions; it will only fire once per request lifecycle despite being called twice.

---
*PR created automatically by Jules for task [16257811514080064063](https://jules.google.com/task/16257811514080064063) started by @gokaiorg*