### PR TITLE
🎨 Palette: [UX improvement] Add standard icons to password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2026-06-12 - Password Toggle Interaction Pattern
+**Learning:** Interactive toggles (like password visibility) with raw text labels ("Show"/"Hide") break immersion and localization, while screen readers prefer standard `aria-label` on the parent interactive element rather than reading individual visual state labels.
+**Action:** Use universally recognized icons (e.g. `Eye`, `EyeOff` from `lucide-react`) combined with `aria-hidden="true"` on the icons, relying on a dynamically updated `aria-label` on the parent `<Button>` to maintain high accessibility and better visual UX.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Replaced the raw text ("Show" and "Hide") inside the password visibility toggle of `LoginForm` with standard `Eye` and `EyeOff` icons from `lucide-react`.
🎯 Why: Text-based toggle buttons are less intuitive, break immersion, and are harder to internationalize. Using standard iconography improves the visual form aesthetics.
♿ Accessibility: The newly added icons have `aria-hidden="true"` applied to them so screen readers do not read redundant info. The parent `<Button>` maintains its dynamically updating `aria-label` which handles accessibility properly.

---
*PR created automatically by Jules for task [1535518398513870012](https://jules.google.com/task/1535518398513870012) started by @gokaiorg*