### PR TITLE
⚡ Bolt: Deduplicate metadata and page queries via React cache()

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
### 💡 What
Wrapped duplicated database queries in `React.cache()` for the dynamic product page (`src/app/[lang]/(shop)/product/[slug]/page.tsx`) and the dynamic content page (`src/app/[lang]/(shop)/[slug]/page.tsx`).

### 🎯 Why
In the Next.js App Router, functions like `generateMetadata` and the page component execute independently. While Next.js automatically deduplicates native `fetch` API calls, it does not intercept or deduplicate SDK calls (like Firebase Admin queries). Consequently, both files were querying the database twice per page load (once for metadata, once for the page content). Using React's `cache()` memoizes the function call per server request, preventing the redundant backend query.

### 📊 Impact
Reduces database reads per page view on product and dynamic shop pages by exactly 50%. This improves server rendering times (TTFB) and reduces Firebase Firestore read costs.

### 🔬 Measurement
Verified locally via code review. The `cache()` function safely scopes memoization to the lifetime of a single server request context in Next.js.

---
*PR created automatically by Jules for task [5366278597697636046](https://jules.google.com/task/5366278597697636046) started by @gokaiorg*