### PR TITLE
⚡ Bolt: Deduplicate Firebase queries using React.cache()

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,14 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt: Deduplicate Firebase query using React.cache().
+// This prevents the same query from running twice per request
+// (once in generateMetadata and once in DynamicPage), halving database reads and improving TTFB.
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,18 +12,26 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+// ⚡ Bolt: Deduplicate Firebase query using React.cache().
+// This prevents the same query from running twice per request
+// (once in generateMetadata and once in ProductPage), halving database reads and improving TTFB.
+const getProduct = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProduct(lang, slug);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +44,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
### 💡 What
Wrapped the `adminDb.collection("...").get()` calls in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`. Added comments to document the optimization.

### 🎯 Why
In Next.js App Router, `generateMetadata` and the main page component often need to fetch the same data. Because native `fetch` is automatically deduplicated but custom backend SDKs (like `firebase-admin`) are not, the server was executing the exact same database query twice per page load, causing a performance bottleneck. 

### 📊 Impact
- Reduces database reads by 50% for dynamic pages and product pages.
- Improves Time to First Byte (TTFB) by eliminating an unnecessary backend roundtrip during SSR.

### 🔬 Measurement
1. Add `console.log("Fetching...")` inside the cached function.
2. Load a product page.
3. Observe that the log only appears once instead of twice.

---
*PR created automatically by Jules for task [13814892027633487554](https://jules.google.com/task/13814892027633487554) started by @gokaiorg*