### PR TITLE
🎨 Palette: Improve password visibility toggle UX in login form

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced the hardcoded "Show" and "Hide" text strings in the password visibility toggle button with standard `Eye` and `EyeOff` icons from `lucide-react`.
**🎯 Why:** Improves visual polish by using recognizable standard icons instead of textual toggles. It makes the form look cleaner and more consistent with modern UI standards.
**📸 Before/After:** The button now displays an eye icon instead of raw text.
**♿ Accessibility:** Maintained the existing `aria-label` on the parent `<Button>` and explicitly added `aria-hidden="true"` to the new SVG icons. This ensures screen readers correctly announce "Show password" or "Hide password" without reading redundant icon text.

---
*PR created automatically by Jules for task [7481083753729225706](https://jules.google.com/task/7481083753729225706) started by @gokaiorg*