### PR TITLE
⚡ Bolt: Deduplicate product database queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-06-14 - Deduplicate Firestore queries in Next.js App Router using React.cache()
+**Learning:** In Next.js App Router applications, data fetching logic inside `generateMetadata` and the actual page component executes independently, leading to identical requests firing twice per page load. While Next.js automatically deduplicates native `fetch()` calls, it does not deduplicate direct database SDK queries (like Firebase Admin's `adminDb.collection().get()`).
+**Action:** When a page needs the same non-`fetch` database data for both `generateMetadata` and the React component, always extract the query logic into a helper function and wrap it with `React.cache()`. This successfully memoizes the request for the lifecycle of the server render, halving the database reads and improving TTFB. Note that Firestore `QuerySnapshot` promises are cacheable by `React.cache()`.

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Metadata } from "next";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
@@ -11,18 +12,22 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProduct = React.cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot.empty ? null : snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProduct(lang, slug);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +40,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
💡 What: Extract the product fetching logic in `src/app/[lang]/(shop)/product/[slug]/page.tsx` into a `getProduct` helper function and wrap it with `React.cache()`.
🎯 Why: In Next.js App Router, `generateMetadata` and the page component execute independently. Without deduplication, the `adminDb.collection("products")` database query executes twice for every page load. While Next.js automatically deduplicates native `fetch` requests, it does not deduplicate third-party SDK database requests like `firebase-admin`.
📊 Impact: Halves the number of Firestore database reads per product page view, significantly improving Time to First Byte (TTFB) and reducing billing costs.
🔬 Measurement: Observe the backend logs or network tab; the product lookup query will now only execute once per request instead of twice.

---
*PR created automatically by Jules for task [9796510556251151260](https://jules.google.com/task/9796510556251151260) started by @gokaiorg*