### PR TITLE
🎨 Palette: Replace text with standard icons in password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**🎨 Palette: Password Visibility Icon UX Upgrade**

💡 **What:**
Replaced the plain text "Show" / "Hide" in the `LoginForm` password toggle button with standard eye (`Eye`) and closed eye (`EyeOff`) icons from `lucide-react`.

🎯 **Why:**
Using universal iconography for standard UI interactions (like password visibility toggles) reduces cognitive load, improves localization flexibility (as standard icons don't require translation), and makes the login interface look more polished and modern. The text version was a bit clunky next to standard input fields.

📸 **Before/After:**
*(Visual change: The "Show"/"Hide" text inside the password field is now represented by the standard `lucide-react` eye icons).*

♿ **Accessibility:**
Maintained the existing accessibility structure by keeping the `aria-label="Show password"` / `"Hide password"` on the parent `<Button>` interactive element, and explicitly adding `aria-hidden="true"` to the new SVG icons. This ensures screen readers announce the exact same clear action text as before, without reading the icon's raw SVG content twice.

---
*PR created automatically by Jules for task [6476191621949982989](https://jules.google.com/task/6476191621949982989) started by @gokaiorg*