### PR TITLE
⚡ Bolt: [Performance] Deduplicate Firestore queries in dynamic page components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-06-15 - Deduplicating Firestore Queries in Next.js
+**Learning:** In Next.js App Router, direct database calls (like `firebase-admin` SDK queries) inside both `generateMetadata` and the page component are not automatically deduplicated like native `fetch` calls, leading to duplicate reads per request.
+**Action:** Always wrap these non-fetch database query functions with `React.cache()` to ensure they only execute once per request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** Wrapped direct Firestore `adminDb.collection(...).get()` queries in React's `cache()` function for dynamic routes (`[slug]/page.tsx` and `product/[slug]/page.tsx`).

🎯 **Why:** In Next.js App Router, functions like `generateMetadata` and the main Page component are executed independently within the same request lifecycle. While Next.js automatically deduplicates native `fetch` API requests, direct SDK calls (like `firebase-admin` queries) are not natively memoized. This caused the application to read the exact same Firestore document twice per user request, increasing both latency and database read costs.

📊 **Impact:** 
- Reduces Firestore read operations by exactly 50% for dynamic product and CMS pages.
- Improves Server-Side Rendering (SSR) Time to First Byte (TTFB) by eliminating an identical, synchronous network call.

🔬 **Measurement:** 
- Monitor Firebase Console -> Firestore Database -> Usage. The read operations per dynamic page visit should be halved.
- Measure TTFB on production for `/product/[slug]` and `/[slug]` routes.

---
*PR created automatically by Jules for task [16848959100145628357](https://jules.google.com/task/16848959100145628357) started by @gokaiorg*