### PR TITLE
🎨 Palette: Add context-aware sr-only text to icon-only Edit buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Context-Aware sr-only Tags vs aria-labels in Translated Content
+**Learning:** For interactive elements in dynamic lists (like "Edit" buttons in a table), using a visibly hidden `<span className="sr-only">` is often preferable to an `aria-label` attribute, particularly in applications utilizing internationalization (`lang`). Automatic translation services frequently ignore `aria-label` attributes but reliably translate standard DOM text nodes, ensuring screen reader users receive localized context.
+**Action:** Default to using `sr-only` spans for screen reader context instead of `aria-label` attributes for icon-only buttons when the application heavily relies on dynamic internationalization or when text needs to be dynamically built using state/props.

--- a/src/app/[lang]/admin/categories/page.tsx
+++ b/src/app/[lang]/admin/categories/page.tsx
@@ -84,6 +84,7 @@ export default async function AdminCategoriesPage({ params }: { params: Promise<
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/categories/${category.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">Edit {lang === 'fr' ? category.nameFr : category.nameEn}</span>
                                             </Link>
                                         </Button>
                                     </td>

--- a/src/app/[lang]/admin/pages/page.tsx
+++ b/src/app/[lang]/admin/pages/page.tsx
@@ -67,6 +67,7 @@ export default async function AdminPagesPage({ params }: { params: Promise<{ lan
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/pages/${page.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">Edit {lang === 'fr' ? page.title_fr : page.title_en}</span>
                                             </Link>
                                         </Button>
                                     </td>

--- a/src/app/[lang]/admin/products/page.tsx
+++ b/src/app/[lang]/admin/products/page.tsx
@@ -101,6 +101,7 @@ export default async function AdminProductsPage({ params }: { params: Promise<{ 
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/products/${product.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">Edit {lang === 'fr' ? product.nameFr : product.nameEn}</span>
                                             </Link>
                                         </Button>
                                     </td>


### PR DESCRIPTION
💡 **What:** Added localized screen-reader-only context spans (`<span className="sr-only">Edit {itemName}</span>`) to the "Pencil" icon buttons in the Admin dashboard tables for Categories, Pages, and Products.
🎯 **Why:** Previously, these buttons only had a generic "Pencil" icon. Screen readers would announce these links generically (e.g., "link", "edit"), leaving users without context of *which* specific item row they were about to edit. By adding the localized name dynamically, it improves navigation for AT users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Fixes WCAG 4.1.2 Name, Role, Value by providing a context-aware Accessible Name to icon-only interactive controls using `sr-only` text, which is preferred over `aria-label` for machine translation compatibility.

---
*PR created automatically by Jules for task [7426302191732274309](https://jules.google.com/task/7426302191732274309) started by @gokaiorg*