### PR TITLE
🎨 Palette: [UX improvement] Replace raw text labels with icons for password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the plain text labels ("Show" / "Hide") inside the password input's visibility toggle button with modern `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** Standardizes the UI to match common user expectations. Icons are faster to visually process than text and take up less horizontal space, resulting in a cleaner and more polished interface on the login page.

📸 **Before/After:** The button now displays an eye icon depending on the state instead of raw text. 

♿ **Accessibility:** Added `aria-hidden="true"` to the newly introduced `<Eye>` and `<EyeOff>` icons to prevent screen readers from announcing decorative icons. The parent `<Button>` retains its existing contextual `aria-label` ("Show password" / "Hide password"), preserving perfect keyboard and screen reader accessibility.

---
*PR created automatically by Jules for task [7910445942030340020](https://jules.google.com/task/7910445942030340020) started by @gokaiorg*