### PR TITLE
⚡ Bolt: [Performance] Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-10-27 - Deduplicate Firebase Admin Queries in App Router
+**Learning:** In Next.js App Router, when `generateMetadata` and a Server Component perform the identical `firebase-admin` query (like `.doc(slug).get()`), the query will run twice per request on the server. Native `fetch` is auto-deduplicated, but `firebase-admin` is not.
+**Action:** Always extract the repeated `adminDb.collection(...).get()` call into a helper function wrapped with `React.cache()` to share the Promise across `generateMetadata` and the component, cutting database reads in half.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { adminDb } from "@/lib/firebase-admin";
+import { cache } from "react";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,18 +12,23 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductBySlug = cache(async (slug: string, slugField: string) => {
+    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(slug, slugField);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -36,13 +42,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(slug, slugField);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
### 💡 What
Wrapped the identical Firestore database queries (`adminDb.collection(...).get()`) in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` within helper functions using `React.cache()`.

### 🎯 Why
In Next.js App Router, while native `fetch` is automatically deduplicated, direct database calls via the `firebase-admin` SDK are not. Because both `generateMetadata` and the default page component were independently making identical database calls to fetch the product/page by its slug, the server was executing two identical queries against Firestore per request.

### 📊 Impact
Reduces database reads by 50% for every hit on dynamic product pages and custom dynamic pages, effectively halving the latency/workload associated with fetching the core document on those routes.

### 🔬 Measurement
Verified via static analysis and tests that the changes are safely isolated within a single request lifecycle (the scope of `React.cache()`). Comparing Firestore read counts before and after on these routes would demonstrate the 1-to-0.5 ratio improvement.

---
*PR created automatically by Jules for task [11850103926199385469](https://jules.google.com/task/11850103926199385469) started by @gokaiorg*