### PR TITLE
🎨 Palette: [UX improvement] Replace text with icons for password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced the plain text "Show" and "Hide" labels with `Eye` and `EyeOff` icons from `lucide-react` for the password visibility toggle button in `src/components/LoginForm.tsx`.

**🎯 Why:** Standard icons provide a cleaner, more universally recognized, and polished user interface for common interactions like toggling password visibility. It saves horizontal space and reduces visual clutter within the input field.

**♿ Accessibility:** The new icons include `aria-hidden="true"`. This is crucial because the parent `<Button>` already possesses a dynamic `aria-label` ("Show password" / "Hide password"). Hiding the icons prevents screen readers from redundantly announcing the icons alongside the button's primary label, maintaining a clean auditory experience.

---
*PR created automatically by Jules for task [6425204441976288719](https://jules.google.com/task/6425204441976288719) started by @gokaiorg*