### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate redundant database queries using React cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-25 - Deduplicate redundant database queries with React cache()
+**Learning:** In the Next.js App Router, using `adminDb.collection(...).get()` in `generateMetadata` and then again in the page component causes the exact same query to run twice per request, effectively doubling read costs and latency. Unlike native `fetch`, Firebase admin queries are not automatically memoized by Next.js.
+**Action:** Extract common Firestore database queries into helper functions and wrap them in React's `cache()` API when the query needs to be shared between `generateMetadata` and the page component, cutting database reads in half without breaking SSR.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** Deduplicated repeated Firebase database queries between `generateMetadata` and Page components across dynamic routes (`product/[slug]` and `[slug]`) by extracting them into helper functions wrapped with `React.cache()`.

🎯 **Why:** In Next.js App Router, while native `fetch` requests are automatically memoized, SDK calls (like Firebase Admin's `.get()`) are not. Because these page components need the same document data as `generateMetadata` to render, the server was making the exact same network roundtrip and database read twice per page load, unnecessarily doubling Firestore costs and inflating Time to First Byte (TTFB).

📊 **Impact:** Cuts database read operations and network requests strictly in half (from 2 to 1) for these specific routes. Improves TTFB on the server during SSR.

🔬 **Measurement:** Verify by running the application and checking the Firebase usage console or network logger; you will see only a single `adminDb` query executed per page load on these dynamic routes instead of two.

---
*PR created automatically by Jules for task [13592518808418738183](https://jules.google.com/task/13592518808418738183) started by @gokaiorg*