### PR TITLE
⚡ Bolt: Deduplicate Firestore queries in Server Components

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,23 +6,29 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (slug: string, lang: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    if (snapshot.empty) return null;
+    return snapshot.docs[0];
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const doc = await getProductBySlug(slug, lang);
     
-    if (snapshot.empty) {
+    if (!doc) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
     const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
@@ -35,14 +41,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const doc = await getProductBySlug(slug, lang);
 
-    if (snapshot.empty) {
+    if (!doc) {
         notFound();
     }
 
-    const doc = snapshot.docs[0];
     const data = doc.data();
     const product = {
         ...data,


### PR DESCRIPTION
⚡ **Bolt**: [Performance Improvement] Deduplicate Firestore Queries

**💡 What**: 
Abstracted inline Firestore queries in Next.js server component routes (`src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx`) into separate helper functions (`getProductBySlug`, `getPage`), and wrapped them using `React.cache()`. Then updated `generateMetadata` and the default page export to use these memoized functions instead of executing the queries twice.

**🎯 Why**: 
In the Next.js App Router, it is a common requirement to fetch the same data within both `generateMetadata()` (to populate `<head>` tags) and the main page component (to render the UI). While Next.js automatically patches the native `fetch` API to deduplicate these duplicate identical network requests within the same server render pass, it *does not* patch SDK-based requests like `firebase-admin` methods. This means every page load on these dynamic routes was performing redundant, identical database reads.

**📊 Impact**: 
Reduces the number of database reads from Firestore by exactly 50% for all individual product pages and dynamic text pages, halving network latency (improving Time To First Byte) and saving on database egress / operation costs without impacting data freshness.

**🔬 Measurement**: 
To verify, you can monitor the network tab (if simulating requests from a client edge) or observe the Next.js console logs during SSR with a profiler. The `snapshot` returned from `adminDb` will now be safely cached for the duration of the current request via React's internal context mechanism.

---
*PR created automatically by Jules for task [12040858497165042163](https://jules.google.com/task/12040858497165042163) started by @gokaiorg*