### PR TITLE
🎨 Palette: [UX improvement] Add sr-only labels to admin edit buttons

### DIFF
--- a/src/app/[lang]/admin/categories/page.tsx
+++ b/src/app/[lang]/admin/categories/page.tsx
@@ -84,6 +84,7 @@ export default async function AdminCategoriesPage({ params }: { params: Promise<
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/categories/${category.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">Edit {lang === 'fr' ? category.nameFr : category.nameEn}</span>
                                             </Link>
                                         </Button>
                                     </td>

--- a/src/app/[lang]/admin/pages/page.tsx
+++ b/src/app/[lang]/admin/pages/page.tsx
@@ -67,6 +67,7 @@ export default async function AdminPagesPage({ params }: { params: Promise<{ lan
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/pages/${page.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">Edit {lang === 'fr' ? page.title_fr : page.title_en}</span>
                                             </Link>
                                         </Button>
                                     </td>

--- a/src/app/[lang]/admin/products/page.tsx
+++ b/src/app/[lang]/admin/products/page.tsx
@@ -101,6 +101,7 @@ export default async function AdminProductsPage({ params }: { params: Promise<{ 
                                         <Button variant="ghost" size="icon" asChild>
                                             <Link href={`/${lang}/admin/products/${product.id}/edit`}>
                                                 <Pencil className="w-4 h-4" />
+                                                <span className="sr-only">Edit {lang === 'fr' ? product.nameFr : product.nameEn}</span>
                                             </Link>
                                         </Button>
                                     </td>


### PR DESCRIPTION
💡 What: Added visually hidden text (using `sr-only` span) inside the icon-only "Edit" links/buttons across the admin tables (Products, Categories, and Pages).
🎯 Why: To provide vital context for screen reader users when navigating the lists, ensuring they hear what specific item the edit button relates to instead of a generic "link".
📸 Before/After: Visual UI remains unchanged.
♿ Accessibility: Improved screen reader support by translating generic icon links into specific actionable names based on the localized item title.

---
*PR created automatically by Jules for task [3584118026288092651](https://jules.google.com/task/3584118026288092651) started by @gokaiorg*