### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateProfile server action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,8 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+
+## 2024-06-25 - IDOR in Profile Updates
+**Vulnerability:** Insecure Direct Object Reference (IDOR) found in `updateProfile` action where any authenticated user could modify other users' profiles since the `uid` argument was not validated against the current session ID.
+**Learning:** In Next.js Server Actions handling user-specific mutations, do not solely rely on generic authentication checks (or lack thereof, since the original code lacked any check).
+**Prevention:** Always verify that `session?.user?.id === uid` unless the user has an explicit admin role before proceeding with profile mutations.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -2,6 +2,7 @@
 
 import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
+import { auth } from "@/auth";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
 
@@ -56,6 +57,17 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    const userRole = (session?.user?.role || "").toLowerCase();
+
+    if (!session?.user?.id) {
+        return { error: "Unauthorized" };
+    }
+
+    if (session.user.id !== uid && userRole !== "admin") {
+        return { error: "Unauthorized" };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `updateProfile` server action. The action accepted a target `uid` but did not verify it against the current authenticated session. This allowed any user (even unauthenticated) to potentially overwrite any other user's profile details.
🎯 **Impact:** Unauthorized account takeover, unauthorized profile modification, and potential data loss/corruption.
🔧 **Fix:** Added a robust session and role authorization barrier at the beginning of the `updateProfile` server action to strictly verify that `session?.user?.id === uid` OR `session?.user?.role === "admin"`.
✅ **Verification:** Verified fix logic, ran `pnpm lint` and `pnpm build` successfully without introducing regressions.

---
*PR created automatically by Jules for task [6439657587142255508](https://jules.google.com/task/6439657587142255508) started by @gokaiorg*