### PR TITLE
🎨 Palette: Replace text with icons for password toggle in LoginForm

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2024-06-20 - Password Toggle UX
+**Learning:** Replaced text labels ("Show"/"Hide") with clear icons (`Eye`, `EyeOff`) inside password input visibility toggles to improve internationalization and visual consistency, while preserving accessible screen-reader text (`aria-label`) on the parent button and `aria-hidden="true"` on the icons.
+**Action:** Always prefer recognizable, semantic icons over plain text for common inline interactive toggles (like password visibility).

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
🎨 Palette: [UX improvement]

**💡 What:** Replaced plain text "Show"/"Hide" labels in the password input visibility toggle with standard `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why:** Standard icons are more universally recognizable, avoid layout shifting, and do not require internationalization/translation strings compared to plain text, improving the overall visual polish and usability of the form.

**♿ Accessibility:** Preserved the dynamic `aria-label` ("Show password" / "Hide password") on the parent interactive `<Button>` element, and added `aria-hidden="true"` to the newly introduced `<Eye>` / `<EyeOff>` icons to prevent screen readers from doubly announcing the elements or interpreting decorative svgs.

---
*PR created automatically by Jules for task [5314431145824854930](https://jules.google.com/task/5314431145824854930) started by @gokaiorg*