### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore Queries in Server Components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-06-19 - [Deduplicate Server Component Queries]
+**Learning:** In Next.js App Router, fetching data with a 3rd party SDK (like Firebase) within both `generateMetadata` and the Page component will cause the query to execute twice unless explicitly deduplicated. While Next.js native `fetch` handles this automatically, SDK calls do not. Wrapping the query function in `React.cache()` perfectly deduplicates these operations across the server request lifecycle, halving the database reads for these dynamic pages.
+**Action:** Always wrap non-fetch database or SDK queries in `React.cache()` if they are invoked independently by multiple Server Component lifecycle methods (like `generateMetadata` and the component itself).

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
⚡ Bolt: Deduplicate Firestore Queries in Server Components

💡 **What:** Wrapped the Firebase Firestore queries in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` using `React.cache()`.

🎯 **Why:** In Next.js App Router, `generateMetadata` and the Page component execute independently. While native `fetch` requests are automatically deduplicated by Next.js, direct calls from 3rd party SDKs (like `firebase-admin`) are not. This causes the exact same database query to run twice for every request to these pages. `React.cache()` deduplicates function calls for the duration of a single server request.

📊 **Impact:** Cuts Firestore read operations in half for dynamic product and CMS pages. Reduces total response time and database billing costs.

🔬 **Measurement:** Verify by observing Network tab or server logs; instead of seeing two identical queries to the `pages` or `products` collection per page load, there will now only be one. Can also be verified by running `pnpm build` which succeeds without errors.

---
*PR created automatically by Jules for task [10457756775092051073](https://jules.google.com/task/10457756775092051073) started by @gokaiorg*