### PR TITLE
🎨 Palette: [UX improvement] Replace raw text with standard icons in password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced the hardcoded english text "Show" and "Hide" with standard `Eye` and `EyeOff` icons from the existing `lucide-react` library within the `<LoginForm>` password visibility toggle button.

**🎯 Why:**
1. **Internationalization (i18n):** The form was already receiving a `dict` prop for localization, but the "Show" / "Hide" text strings were hardcoded in English inside the component, breaking localization patterns. Using universal icons entirely eliminates the need to translate these terms.
2. **Standardization:** Eye icons are the universal UI standard for password visibility toggles.
3. **Clutter Reduction:** Reduces visual noise inside the input field context.

**♿ Accessibility:**
The toggle button already utilized dynamic `aria-label` attributes (`"Hide password"` / `"Show password"`). The new SVG icons have been explicitly marked with `aria-hidden="true"` to prevent screen readers from attempting to announce the SVG elements redundantly, relying entirely on the parent button's accurate `aria-label`.

---
*PR created automatically by Jules for task [15423194358540467978](https://jules.google.com/task/15423194358540467978) started by @gokaiorg*