### PR TITLE
⚡ Bolt: Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-06-20 - [Deduplicate Firestore Queries in App Router]
+**Learning:** In Next.js App Router, while native `fetch` requests are automatically deduplicated during the request lifecycle, direct database queries (like `firebase-admin` Firestore `get()` calls) are NOT. If the exact same query is run in both `generateMetadata` and the main page component, it will hit the database twice per request, doubling latency and costs.
+**Action:** Always wrap these non-fetch database query functions with `React.cache()` to ensure they only execute once per request lifecycle. Firestore `QuerySnapshot` promises returned by `adminDb...get()` are serializable and perfectly cacheable by `React.cache()`.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
### 💡 What
Wrapped the Firestore database queries in `React.cache()` for the dynamic routes `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx`.

### 🎯 Why
In the Next.js App Router, while native `fetch` requests are automatically deduplicated during a request's lifecycle, direct database operations (like those using `firebase-admin`'s `adminDb...get()`) are not. Because these dynamic pages fetch the exact same document in both the `generateMetadata` function and the main `Page` component, Next.js was executing two identical database reads per incoming request, doubling latency and Firebase billing for these routes.

### 📊 Impact
*   **Performance:** Cuts the number of database reads per page view in half.
*   **Cost:** Reduces Firestore read operations by 50% for these dynamic routes.
*   **Latency:** Improves Time to First Byte (TTFB) by eliminating the second redundant network call to Firestore.

### 🔬 Measurement
Run `pnpm build` and `pnpm start` with a connected Firebase project. Observe the network tab or Firebase console metrics; there will now only be 1 read per page load instead of 2.

---
*PR created automatically by Jules for task [12484492489047177839](https://jules.google.com/task/12484492489047177839) started by @gokaiorg*