### PR TITLE
🎨 Palette: [UX improvement] Add Eye/EyeOff icons to password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2024-05-24 - Testing Isolated Components with Empty Dictionaries
+**Learning:** When using Playwright to visually test an isolated React component (like `LoginForm`) that relies on a localization `dict` prop, passing an empty object (`dict={{}}`) causes text-based labels to render empty. This causes Playwright locators relying on text, like `get_by_label("Email")` or `get_by_role("textbox", name="Email")`, to fail and timeout.
+**Action:** When creating a mock page to test an isolated localized component, either supply realistic mock values in the `dict` object (e.g., `dict={{ email: "Email", password: "Password" }}`) or use robust CSS ID locators (e.g., `page.locator("#email")`) in the Playwright script to bypass missing text dependencies.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** Replaced raw text labels ("Show"/"Hide") in the password visibility toggle of the `LoginForm` component with standard `Eye` and `EyeOff` icons from `lucide-react`.
**🎯 Why:** Improves user interface intuitiveness by using universally recognized icons instead of text, making the form cleaner and more polished, particularly benefiting non-English speakers.
**♿ Accessibility:** The parent `<Button>` retains its dynamic `aria-label` ("Show password" / "Hide password") for screen readers, and the new icons are explicitly marked with `aria-hidden="true"` to prevent redundant or confusing announcements.

---
*PR created automatically by Jules for task [13783155041467521455](https://jules.google.com/task/13783155041467521455) started by @gokaiorg*