### PR TITLE
⚡ Bolt: Deduplicate Firestore queries in Next.js Server Components using React cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2026-06-21 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** In Next.js App Router, while native `fetch` requests are automatically deduplicated during a single request lifecycle (e.g., between `generateMetadata` and the page component), direct database calls using SDKs like `firebase-admin` are not. This results in duplicate, unnecessary database reads. Firestore's `QuerySnapshot` promises returned by `adminDb.collection(...).get()` are serializable and can be safely wrapped in React's `cache()` function.
+**Action:** When a server component and its `generateMetadata` function need the same Firestore data, always wrap the query function with `React.cache()` to ensure the database is only hit once per request, halving the database reads for that page.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,10 +12,14 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 What: Wrapped Firestore database queries with `React.cache()` in dynamic product and page routes.
🎯 Why: Next.js automatically deduplicates native `fetch` requests, but direct database SDK calls (like `firebase-admin`) execute twice when used in both `generateMetadata` and the page component. This causes unnecessary database reads and delays rendering.
📊 Impact: Halves the number of database reads per request on dynamic product and content pages, reducing latency and backend load.
🔬 Measurement: Verify by checking Firestore read usage or adding console logs inside the cached function; it should only execute once per page load despite being called in two places.

---
*PR created automatically by Jules for task [13011870307905285232](https://jules.google.com/task/13011870307905285232) started by @gokaiorg*