### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with icons

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the plain "Show" / "Hide" text in the password visibility toggle with standard `Eye` and `EyeOff` icons from `lucide-react`.
🎯 **Why:** To make the user interface cleaner and more universally intuitive. Icons are faster to recognize than text and save horizontal space.
♿ **Accessibility:** Added `aria-hidden="true"` to the new icons to prevent redundant screen reader announcements, ensuring that the existing, context-rich `aria-label` on the parent `<Button>` remains the sole source of accessible instruction.

---
*PR created automatically by Jules for task [7529868533984218287](https://jules.google.com/task/7529868533984218287) started by @gokaiorg*