### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate identical Firebase database queries per request lifecycle

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,9 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2025-04-04 - Next.js Request-Level Data Deduplication
+**Learning:** In Next.js App Router, when  and a page component need the same data, non-`fetch` database calls (like Firebase Admin SDK queries) will execute twice per request. While native `fetch` is automatically deduplicated, direct database queries are not.
+**Action:** Always wrap non-`fetch` database lookup functions (e.g., Firestore queries) with `React.cache()` to deduplicate execution. This ensures the expensive backend query only runs once per request lifecycle, halving the database reads and significantly improving Time To First Byte (TTFB).
+## 2025-04-04 - Next.js Request-Level Data Deduplication
+**Learning:** In Next.js App Router, when `generateMetadata` and a page component need the same data, non-`fetch` database calls (like Firebase Admin SDK queries) will execute twice per request. While native `fetch` is automatically deduplicated, direct database queries are not.
+**Action:** Always wrap non-`fetch` database lookup functions (e.g., Firestore queries) with `React.cache()` to deduplicate execution. This ensures the expensive backend query only runs once per request lifecycle, halving the database reads and significantly improving Time To First Byte (TTFB).

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,24 +6,40 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
     
     if (snapshot.empty) {
+        return null;
+    }
+
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    return {
+        ...data,
+        id: doc.id,
+        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
+        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
+    } as Product;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const product = await getProductBySlug(lang, slug);
+
+    if (!product) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,21 +51,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const product = await getProductBySlug(lang, slug);
 
-    if (snapshot.empty) {
+    if (!product) {
         notFound();
     }
-
-    const doc = snapshot.docs[0];
-    const data = doc.data();
-    const product = {
-        ...data,
-        id: doc.id,
-        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
-        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
-    } as Product;
 
     const dict = await getDictionary(lang as Locale);
     const shopDict = dict.shop;


### PR DESCRIPTION
💡 **What:** 
Wrapped the direct Firestore query functions (`getPage` and `getProductBySlug`) with React's `cache()` helper in the dynamic `[slug]` and `product/[slug]` routes. 

🎯 **Why:** 
In Next.js App Router, the `generateMetadata` function and the default page component both run during the same server request lifecycle. Since Next.js only automatically deduplicates native `fetch()` API calls, direct database queries (like `adminDb.collection(...).get()`) were executing twice—once to resolve metadata (title/description) and again to render the actual component tree. This created a performance bottleneck and doubled the backend database read operations.

📊 **Impact:** 
- Cuts the number of backend database reads exactly in half for these heavily trafficked dynamic pages.
- Significantly improves Time To First Byte (TTFB) by eliminating the redundant network roundtrip to Firestore during Server-Side Rendering.

🔬 **Measurement:** 
1. Build the app (`pnpm build`) and start it (`pnpm start`).
2. Navigate to a specific product page (e.g., `/en/product/some-product`).
3. Using an APM tool (or standard console logs within the cached function body), you will observe that the Firestore lookup only fires *once* per page load, rather than twice.

---
*PR created automatically by Jules for task [8925396036846881812](https://jules.google.com/task/8925396036846881812) started by @gokaiorg*