### PR TITLE
🎨 Palette: [UX improvement] Replace text labels with icons for password visibility toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff aria-hidden="true" className="h-4 w-4" /> : <Eye aria-hidden="true" className="h-4 w-4" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Replaced the "Show" and "Hide" raw text in the password visibility toggle button with `Eye` and `EyeOff` icons from `lucide-react`.
🎯 Why: Text labels within small input icons can feel clunky and take up unnecessary space. Standard icons provide a cleaner, more recognizable user interface pattern for this common interaction.
♿ Accessibility: The parent `<Button>` already maintains a dynamic `aria-label` ("Show password" / "Hide password") for screen readers. Added `aria-hidden="true"` to the new lucide icons to prevent redundant or confusing screen reader announcements.

---
*PR created automatically by Jules for task [1563982069412674548](https://jules.google.com/task/1563982069412674548) started by @gokaiorg*