### PR TITLE
⚡ Bolt: Deduplicate duplicate Firestore queries in Next.js Server Components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2025-06-24 - Deduplicate non-fetch DB queries with React.cache()
+**Learning:** In Next.js App Router, while native `fetch` API calls are automatically deduplicated during a single request lifecycle, direct database queries (like `firebase-admin` SDK calls) are not. Calling the same query in both `generateMetadata` and the Page component creates an immediate performance bottleneck by doubling the database reads per request.
+**Action:** Always extract non-`fetch` database queries that are reused across a request (e.g., between metadata generation and page rendering) into a separate function, and explicitly wrap that function with `React.cache()`. This ensures the database query is only executed once per request, optimizing performance and reducing costs.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    return adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 What: Extracted and wrapped `firebase-admin` database queries inside `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`.

🎯 Why: In Next.js App Router, the native `fetch` API is automatically deduplicated across a request lifecycle, but direct database queries (like those from the Firebase Admin SDK) are not. Because the application was querying the same document both in `generateMetadata` and the Page component, it was executing identical queries twice per page load, creating a significant performance and cost bottleneck. `React.cache()` manually memoizes the promise, ensuring the backend is only hit once.

📊 Impact: Reduces database reads by exactly 50% on these server-rendered pages and slightly improves the Time to First Byte (TTFB) by eliminating the second redundant network roundtrip.

🔬 Measurement: The optimization can be verified by inspecting the network logs or Firestore billing metrics. The build correctly compiles, indicating the returned snapshot promises are perfectly serializable by `React.cache()`.

---
*PR created automatically by Jules for task [1834747128742530673](https://jules.google.com/task/1834747128742530673) started by @gokaiorg*