### PR TITLE
🎨 Palette: [UX improvement] Replace raw text labels with recognizable icons for password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the raw text labels ("Show" / "Hide") with standard, recognizable icons (`Eye` / `EyeOff`) from `lucide-react` for the password visibility toggle in the LoginForm.

🎯 **Why:** Standard icons are much faster to visually process and are an established pattern for password toggles, resulting in a cleaner and more intuitive UI. The raw text labels were slightly clunky.

📸 **Before/After:** The button previously contained raw text. It now dynamically displays the `Eye` or `EyeOff` icon depending on the state.

♿ **Accessibility:**
- The parent `<Button>` already has a descriptive, dynamically updating `aria-label` ("Show password" / "Hide password").
- Added `aria-hidden="true"` to the new `<Eye>` and `<EyeOff>` icons to prevent screen readers from redundantly announcing the SVG structure, ensuring a clean and focused announcement when the toggle is focused.

---
*PR created automatically by Jules for task [7500509981942713073](https://jules.google.com/task/7500509981942713073) started by @gokaiorg*