### PR TITLE
🎨 Palette: [UX] Use icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Interactive Password Visibility Toggles
+**Learning:** Raw text like "Show" and "Hide" for password visibility toggles is less recognizable, poorly internationalized natively, and requires additional mental overhead to parse compared to universal standard icons.
+**Action:** Always replace raw text labels on interactive toggles (like password visibility) with universally recognizable standard icons (e.g., Eye/EyeOff from lucide-react) equipped with `aria-hidden="true"`, ensuring the parent interactive element (e.g., `<Button>`) retains a clear, localized, explicit `aria-label`.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff aria-hidden="true" className="h-4 w-4" /> : <Eye aria-hidden="true" className="h-4 w-4" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
### 🎨 Palette: [UX improvement] Replace text with icons for password visibility toggle

💡 **What:** 
Replaced the hardcoded raw text ("Show" and "Hide") inside the password visibility toggle button on the login form with standard `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** 
Universal icons are immediately recognizable and reduce cognitive load for users trying to reveal their password. Additionally, relying on icons removes hardcoded English strings from the UI, natively improving internationalization without requiring extra translation dictionary entries.

📸 **Before/After:** 
*Before:* Button read text "Show" or "Hide"
*After:* Button displays standard standard 👁️/👁️‍🗨️ SVG icons.

♿ **Accessibility:** 
The new `Eye` and `EyeOff` icons are correctly hidden from screen readers using `aria-hidden="true"`. The parent `<Button>` element remains fully keyboard accessible and retains its context-aware explicit `aria-label` ("Show password" / "Hide password") which announces correctly via screen readers without doubling up on icon reading.

---
*PR created automatically by Jules for task [2718063925785774911](https://jules.google.com/task/2718063925785774911) started by @gokaiorg*