### PR TITLE
⚡ Bolt: Deduplicate Firestore queries with React Cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-06-25 - React Cache for Firestore Query Deduplication
+**Learning:** In Next.js App Router, direct database queries using the Firebase Admin SDK inside `generateMetadata` and the Page component are executed twice, resulting in redundant network requests and database costs. Unlike native `fetch`, these are not automatically deduplicated.
+**Action:** Always wrap non-fetch database query functions inside server components and route handlers (e.g., `adminDb.collection(...).get()`) with `React.cache()` to enforce single execution per request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (lang: string, slug: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
## ⚡ Bolt: Deduplicate Firestore queries with React Cache

### 💡 What
Wrapped identical Firestore queries inside `generateMetadata` and `ProductPage`/`DynamicPage` with `React.cache()`.

### 🎯 Why
In the Next.js App Router, any data fetching done within `generateMetadata` and the Page component that doesn't use native `fetch` (such as the `firebase-admin` SDK) will execute twice per request lifecycle unless explicitly memoized. This caused redundant network requests and N+1 read costs to the backend database.

### 📊 Impact
Reduces database reads per initial page load by exactly 50% for dynamic pages (e.g., `/[slug]`) and product pages (`/product/[slug]`). Faster Time To First Byte (TTFB).

### 🔬 Measurement
Verify by checking the Firebase console read count or inspecting network traces. The query is now evaluated once, and the second call resolves immediately from React's cache.

---
*PR created automatically by Jules for task [5810807952915344748](https://jules.google.com/task/5810807952915344748) started by @gokaiorg*