### PR TITLE
🎨 Palette: [UX improvement] Use icons for password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-05-18 - Tooling Cleanup Awareness
+**Learning:** Running `pnpm install` in this environment updates the lockfile from v6.0 to v9.0+ because of the system's pnpm version. This causes a massive (> 1000 lines) unintended file modification.
+**Action:** Always restore the `pnpm-lock.yaml` file after running `pnpm install` and before committing to ensure the change stays within the 50-line boundary.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What**: Replaced the raw text "Show" and "Hide" with standard `Eye` and `EyeOff` icons in the password toggle button within `LoginForm.tsx`.
🎯 **Why**: Using standardized icons for password visibility saves horizontal space and creates a cleaner, more modern, and universally recognizable UI compared to plain text toggles.
📸 **Before/After**: See attached Playwright verification video/screenshot.
♿ **Accessibility**: Added `aria-hidden="true"` to the new icons so screen readers do not attempt to read them out loud, while keeping the explicit `aria-label` ("Show password" / "Hide password") on the parent `<Button>` interactive element for context-aware announcements.

---
*PR created automatically by Jules for task [403799519991708199](https://jules.google.com/task/403799519991708199) started by @gokaiorg*