### PR TITLE
🎨 Palette: [Add loading spinner to admin forms]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## $(date +%Y-%m-%d) - Adding Loading Spinners to Form Buttons
+**Learning:** For user experience and accessibility, forms should provide a clear indication that a submission is in progress. Adding a loading spinner to the submit button when `isPending` is true is a simple and effective way to achieve this.
+**Action:** When implementing forms with `useTransition` or other asynchronous submission handlers, ensure the submit button displays a loading indicator (like `Loader2` from `lucide-react`) and is disabled during the submission process.

--- a/src/components/admin/CategoryForm.tsx
+++ b/src/components/admin/CategoryForm.tsx
@@ -10,6 +10,7 @@ import { createCategory, updateCategory } from "@/actions/admin";
 import { categorySchema } from "@/schemas/admin";
 
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import {
     Form,
     FormControl,
@@ -181,7 +182,14 @@ export function CategoryForm({ dict, lang, initialData }: { dict: Record<string,
                 </Accordion>
 
                 <Button type="submit" disabled={isPending}>
-                    {isPending ? dict.submitting : dict.submit}
+                    {isPending ? (
+                        <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            {dict.submitting}
+                        </>
+                    ) : (
+                        dict.submit
+                    )}
                 </Button>
             </form>
         </Form>

--- a/src/components/admin/PageForm.tsx
+++ b/src/components/admin/PageForm.tsx
@@ -10,6 +10,7 @@ import { updatePage } from "@/actions/admin";
 import { pageSchema } from "@/schemas/admin";
 
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import {
     Form,
     FormControl,
@@ -179,7 +180,14 @@ export function PageForm({ dict, lang, initialData }: { dict: any; lang: string;
                 </Accordion>
 
                 <Button type="submit" disabled={isPending}>
-                    {isPending ? dict.forms.submitting : dict.forms.submit}
+                    {isPending ? (
+                        <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            {dict.forms.submitting}
+                        </>
+                    ) : (
+                        dict.forms.submit
+                    )}
                 </Button>
             </form>
         </Form>

--- a/src/components/admin/ProductForm.tsx
+++ b/src/components/admin/ProductForm.tsx
@@ -10,6 +10,7 @@ import { createProduct, updateProduct } from "@/actions/admin";
 import { productSchema } from "@/schemas/admin";
 
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import {
     Form,
     FormControl,
@@ -289,7 +290,14 @@ export function ProductForm({ categories, dict, lang, initialData }: { categorie
                 </div>
 
                 <Button type="submit" disabled={isPending}>
-                    {isPending ? dict.submitting : dict.submit}
+                    {isPending ? (
+                        <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            {dict.submitting}
+                        </>
+                    ) : (
+                        dict.submit
+                    )}
                 </Button>
             </form>
         </Form>


### PR DESCRIPTION
**💡 What**: Added a loading spinner (`Loader2` from `lucide-react`) to the submit buttons in `ProductForm`, `CategoryForm`, and `PageForm` components when `isPending` is true.

**🎯 Why**: Without visual feedback, users might think the form submission failed or is frozen, potentially leading to multiple clicks or frustration. The spinner provides clear communication that the application is processing the request.

**♿ Accessibility**: This provides a visual cue that the form is processing, which improves the overall user experience. The button is already disabled during the pending state, which prevents multiple submissions.

---
*PR created automatically by Jules for task [3145720918792437236](https://jules.google.com/task/3145720918792437236) started by @gokaiorg*