### PR TITLE
🎨 Palette: [UX improvement] Replace raw text password toggle with icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,8 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2024-10-24 - Interactive Component Fallbacks
+
+**Learning:** When testing standalone Next.js components for frontend UI verification, global layout structures (e.g., `<ThemeProvider>`) and database-driven contexts must be bypassed or mocked using raw HTML injections in Playwright. Interactive components like password toggles require visual confirmation because the raw text ("Show"/"Hide") takes up unexpected spatial room compared to uniform standard icons like `Eye`/`EyeOff`.
+
+**Action:** Before rendering isolated UI elements in verification scripts, always check the `Palette` memory directives to construct a resilient HTML skeleton that includes the CSS CDNs and JS libraries matching the project (like Tailwind and Lucide) rather than attempting to boot up the whole Next.js application if missing local credentials block rendering.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:**
Replaced the plain text "Show" and "Hide" labels inside the password visibility toggle button with standard, recognizable `Eye` and `EyeOff` icons from the existing `lucide-react` library.

**🎯 Why:**
Raw text inside a small toggle button takes up more horizontal space and looks less polished. Using widely recognized eye icons creates a more intuitive and visually cohesive user experience for password inputs, aligning with modern design conventions.

**📸 Before/After:**
- *Before:* The button displayed literal "Show" or "Hide" text next to the password input field.
- *After:* The button displays a sleek `Eye` icon (when hidden) or an `EyeOff` icon (when shown).

**♿ Accessibility:**
The parent `<Button>` element already contained an explicit context-aware `aria-label` ("Show password" / "Hide password"). To prevent double-reading by screen readers, `aria-hidden="true"` was explicitly added to the injected `Eye` and `EyeOff` icons. This ensures that visual users get a clear icon while screen reader users continue to hear a clear, descriptive label.

---
*PR created automatically by Jules for task [2691025680353757446](https://jules.google.com/task/2691025680353757446) started by @gokaiorg*