### PR TITLE
⚡ Bolt: [performance optimization] deduplicate metadata queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-18 - Deduplicate Next.js Server Component Database Queries
+**Learning:** In Next.js App Router, while native `fetch` is automatically deduplicated across the request lifecycle, direct backend SDK calls (like `adminDb...get()` using `firebase-admin`) are not. If both `generateMetadata` and a page component query the exact same document, Next.js will execute two distinct database queries, increasing TTFB and database costs.
+**Action:** Always wrap non-fetch database query functions with `React.cache()` to ensure they execute only once per server request lifecycle. `QuerySnapshot` promises return perfectly serializable data, making them ideal candidates for this caching pattern.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,12 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// deduplicate metadata queries using React cache
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,21 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// deduplicate metadata queries using React cache
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    return adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +42,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
### 💡 What
Wrapped direct `firebase-admin` database queries within `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` using `React.cache()`.

### 🎯 Why
In Next.js App Router, while native `fetch` requests are automatically deduplicated during the server request lifecycle, direct SDK calls (like those to Firestore) are not. Because both `generateMetadata` and the default page export independently query the exact same document, Next.js was executing two identical, redundant database reads, blocking the render sequence unnecessarily.

### 📊 Impact
Reduces duplicate read queries for pages and product pages by 50%. Improves Time To First Byte (TTFB) since the page component no longer waits for a secondary database fetch to complete, and halves Firestore read costs for these high-traffic routes.

### 🔬 Measurement
Run `pnpm build` and verify that the page statically renders. At runtime, observe server logs or network traces to confirm that the `adminDb.collection(...).get()` query only fires once per server-side render per path.

---
*PR created automatically by Jules for task [4192618109288528149](https://jules.google.com/task/4192618109288528149) started by @gokaiorg*