### PR TITLE
⚡ Bolt: Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-05-24 - Deduplicate Firestore Queries in App Router
+**Learning:** In Next.js App Router, dynamic routes often call the same database query in both `generateMetadata` and the default page component. While Next.js automatically deduplicates native `fetch` requests, it does not deduplicate arbitrary SDK calls (like `adminDb.collection(...).get()`). This causes the database query to run twice per request, doubling latency and reads.
+**Action:** Always wrap non-fetch database query functions inside `React.cache()` when they are called in both `generateMetadata` and the page component. This ensures the promise is cached and the query is only executed once per request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = React.cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Metadata } from "next";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
@@ -11,10 +12,14 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = React.cache(async (slugField: string, slug: string) => {
+    return adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
### 💡 What:
Wrapped identical Firestore queries inside `React.cache()` in two dynamic Next.js App Router files: `[slug]/page.tsx` and `product/[slug]/page.tsx`.

### 🎯 Why:
In the Next.js App Router, functions like `generateMetadata` and the default page component run within the same request lifecycle. While Next.js natively deduplicates `fetch` requests, it does not deduplicate direct database SDK calls (like `adminDb.collection().get()`). As a result, the exact same query was executing twice per page load, unnecessarily doubling the database latency and the number of reads. Wrapping the query function in `React.cache()` ensures that the database is only hit once per request.

### 📊 Impact:
- Cuts database reads in half for these heavily trafficked dynamic pages.
- Significantly reduces the Time To First Byte (TTFB) and overall server response time.

### 🔬 Measurement:
- Checked application using `pnpm build` and `pnpm lint`.
- Verified the fix conceptually matches Next.js and React official recommendations for caching non-fetch responses.

---
*PR created automatically by Jules for task [18177628282342878997](https://jules.google.com/task/18177628282342878997) started by @gokaiorg*