### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries in Product Page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-06-30 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** In Next.js App Router, while native `fetch` requests are automatically deduplicated during a single server request lifecycle (e.g., when called in both `generateMetadata` and the main page component), direct database calls using SDKs like `firebase-admin` (`adminDb.collection().get()`) are not. This results in duplicate database queries and increased latency.
+**Action:** Always wrap these non-fetch, direct database query functions with `React.cache()` to ensure they only execute once per request lifecycle. The Firestore `QuerySnapshot` promises are fully serializable and work perfectly with `cache()`.

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,22 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// Optimization: Wrap Firestore query with React.cache() to deduplicate requests
+// across generateMetadata and the main page component in a single server request lifecycle.
+const getProduct = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** Wrapped the `adminDb.collection("products").where(...).limit(1).get()` query in `React.cache()` by abstracting it into a `getProduct` helper function in the Dynamic Product Page. Added comments explaining the optimization.

🎯 **Why:** In the Next.js App Router, while native `fetch` requests are automatically deduplicated during a single server request lifecycle (e.g., when called in both `generateMetadata` and the main page component), direct database calls using SDKs like `firebase-admin` are not. This resulted in the exact same Firestore query executing twice per page load, causing unnecessary network latency and double database reads.

📊 **Impact:** Reduces database reads per product page request by exactly 50% (from 2 queries down to 1). Reduces Server-Side Rendering (SSR) Time To First Byte (TTFB) by the duration of one database network roundtrip.

🔬 **Measurement:** You can verify this by looking at Firestore usage logs or measuring the Next.js server trace during page loads. No regressions were found during `pnpm lint` and `pnpm build`.

---
*PR created automatically by Jules for task [4968666457704776458](https://jules.google.com/task/4968666457704776458) started by @gokaiorg*