### PR TITLE
🎨 Palette: [UX improvement] Replace text labels with icons on password toggle

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 What: Replaced hardcoded "Show" and "Hide" text labels on the password visibility toggle in `LoginForm.tsx` with standard `Eye` and `EyeOff` icons from `lucide-react`.
🎯 Why: Text labels for common UI actions can be clunky, and since this form uses a `dict` for localization, hardcoded English text was suboptimal. Icons provide a universally recognizable, modern UX pattern for password visibility.
📸 Before/After: Visual changes show standard eye icons instead of text.
♿ Accessibility: The parent `<Button>` already has an appropriate, dynamic `aria-label` ("Show password" / "Hide password"). I added `aria-hidden="true"` to the newly inserted SVG icons to ensure screen readers do not double-read or get confused by the raw SVG content.

---
*PR created automatically by Jules for task [12918153441187563290](https://jules.google.com/task/12918153441187563290) started by @gokaiorg*