### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2025-07-01 - Deduplicate SDK database calls in Next.js Server Components
+**Learning:** In Next.js App Router, `fetch` calls are automatically deduplicated during rendering. However, native database SDK calls (like `adminDb.collection().get()`) are NOT deduplicated. When both `generateMetadata` and the page component execute the same query, it results in two separate database reads, doubling the backend latency and cost.
+**Action:** Always wrap redundant database query functions (like `getPage` or `getProduct`) with `React.cache()` to ensure they execute exactly once per request lifecycle, effectively sharing the `QuerySnapshot` or data object between the metadata phase and the render phase.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,24 +6,40 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProduct = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
-    
+
     if (snapshot.empty) {
+        return null;
+    }
+
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    return {
+        ...data,
+        id: doc.id,
+        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
+        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
+    } as Product;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const product = await getProduct(lang, slug);
+
+    if (!product) {
         return {
             title: "Product Not Found",
         };
     }
 
-    const doc = snapshot.docs[0];
-    const product = doc.data() as Product;
     const title = lang === 'fr' ? product.nameFr : product.nameEn;
     const description = lang === 'fr' ? product.descriptionFr : product.descriptionEn;
 
@@ -35,21 +51,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const product = await getProduct(lang, slug);
 
-    if (snapshot.empty) {
+    if (!product) {
         notFound();
     }
-
-    const doc = snapshot.docs[0];
-    const data = doc.data();
-    const product = {
-        ...data,
-        id: doc.id,
-        createdAt: data?.createdAt?.toDate ? data.createdAt.toDate().toISOString() : (data?.createdAt || null),
-        updatedAt: data?.updatedAt?.toDate ? data.updatedAt.toDate().toISOString() : (data?.updatedAt || null),
-    } as Product;
 
     const dict = await getDictionary(lang as Locale);
     const shopDict = dict.shop;


### PR DESCRIPTION
**💡 What:** 
Wrapped the database fetching logic in `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` with `React.cache()`.

**🎯 Why:**
In Next.js App Router, when `generateMetadata` and the page component fetch the same data using an external SDK (like Firebase Admin), Next.js does not automatically deduplicate those requests (unlike native `fetch()`). This caused the application to query Firestore twice per page load, increasing Time To First Byte (TTFB) and doubling database read costs.

**📊 Impact:**
- Reduces database reads by 50% for dynamic pages and product pages.
- Improves Server-Side Rendering (SSR) latency by halving the network roundtrips to Firestore during rendering.

**🔬 Measurement:**
- Inspect Next.js server logs or Firestore usage logs when navigating to a product or dynamic page. Before, two identical queries would fire; now, only one fires per request lifecycle.
- Verify with `pnpm build` (which still passes successfully without type errors).

---
*PR created automatically by Jules for task [2238310733910574375](https://jules.google.com/task/2238310733910574375) started by @gokaiorg*