### PR TITLE
🎨 Palette: [UX improvement] Use standard icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## $(date +%Y-%m-%d) - Standard Icons for Text Labels
+**Learning:** Raw text labels like "Show" or "Hide" for common interactive actions (like password visibility toggles) take up unnecessary space and are less universally recognized than standard icons (like an Eye).
+**Action:** Replace raw text labels for standard toggles with universally recognized lucide-react icons equipped with `aria-hidden="true"`, ensuring the parent interactive element retains its explicit `aria-label`.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What**: Replaced the text "Show" and "Hide" with standard `Eye` and `EyeOff` icons from `lucide-react` in the login/signup form.
🎯 **Why**: Using universally recognized icons for password visibility toggles is a more standard design pattern. It reduces visual clutter, is language-agnostic, and improves the overall intuitiveness of the form.
📸 **Before/After**: The button in the password field now displays an icon instead of text.
♿ **Accessibility**: The standard text labels were correctly maintained as an `aria-label` on the parent button. The newly added SVG icons have been explicitly marked with `aria-hidden="true"` to prevent screen readers from announcing them redundantly.

---
*PR created automatically by Jules for task [10556128480799409680](https://jules.google.com/task/10556128480799409680) started by @gokaiorg*