### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,10 +12,14 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 What: Wrapped Firestore database queries in `React.cache()` inside `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx`.

🎯 Why: In Next.js App Router, `generateMetadata` and the default exported page component often need to fetch the exact same data. Native `fetch` is deduplicated automatically, but direct database calls (like `adminDb.collection(...).get()`) are not. This causes the database query to run twice per request, doubling latency and read costs. By wrapping the query functions in `React.cache()`, Next.js will execute the query once and return the cached `QuerySnapshot` for subsequent calls in the same server request lifecycle.

📊 Impact: Reduces Firestore database read operations by 50% for dynamic page and product page requests, directly improving Time To First Byte (TTFB) and reducing billing costs.

🔬 Measurement: Verified that the Next.js build succeeds, TypeScript types map correctly, and `generateMetadata` and the main component can safely share the cached Firebase DocumentData. Next.js server-side logging in development will now only show a single query execution instead of two for these routes.

---
*PR created automatically by Jules for task [2484930614434790705](https://jules.google.com/task/2484930614434790705) started by @gokaiorg*