### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate metadata Firestore queries with React.cache

### DIFF
--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,20 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (slug: string, lang: string) => {
+    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slug, lang);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slug, lang);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What**: Deduplicated Firestore database reads on dynamic shop routes (`[slug]` and `product/[slug]`) by wrapping identical `firebase-admin` queries in `React.cache()`.
🎯 **Why**: In Next.js App Router, custom third-party database fetches (unlike the native `fetch` API) are not automatically deduplicated. Consequently, `adminDb.collection().get()` was executing twice per page request—once during `generateMetadata` and again during the main page component rendering—causing unnecessary database read operations and increasing server latency.
📊 **Impact**: Reduces Firestore reads by 50% for dynamic shop and product pages, lowering database read costs and significantly improving Time To First Byte (TTFB).
🔬 **Measurement**: Verify by adding `console.log` inside the `getPage` or `getProductSnapshot` utility. When loading a product or dynamic page, the log will now only appear once per server request instead of twice. Build succeeds and lint passes.

---
*PR created automatically by Jules for task [941188137504142930](https://jules.google.com/task/941188137504142930) started by @gokaiorg*