### PR TITLE
🎨 Palette: [UX improvement] Enhance password visibility toggle with icons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-05-18 - [Password Visibility Toggle Icons]
+**Learning:** For interactive toggles like password visibility, raw text labels ("Show" / "Hide") can be suboptimal for UX and i18n compared to universally recognized icons.
+**Action:** Replace raw text labels with standard recognizable icons (e.g., `Eye`/`EyeOff` from `lucide-react`) equipped with `aria-hidden="true"`, ensuring the explicit `aria-label` remains on the parent interactive element (e.g., `<Button>`).

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff className="h-4 w-4" aria-hidden="true" /> : <Eye className="h-4 w-4" aria-hidden="true" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded 'Show' / 'Hide' text labels in the password visibility toggle of the `LoginForm` with `Eye` and `EyeOff` icons from `lucide-react`.

🎯 **Why:** Raw text labels for interactive UI toggles (especially inside input fields) can be suboptimal for UX and internationalization. Replacing them with universally recognized icons provides a cleaner, more intuitive interface and prevents potential layout shifts that can occur between varying text lengths across different languages.

📸 **Before/After:** The toggle now visually aligns with standard authentication UX patterns, displaying an eye icon instead of explicit text.

♿ **Accessibility:** Added `aria-hidden="true"` to the newly introduced icons. The surrounding `<Button>` already contains a dynamically updating `aria-label` ("Hide password" / "Show password"), ensuring screen readers will correctly announce the action without redundantly reading the icon elements.

---
*PR created automatically by Jules for task [13948555314372306568](https://jules.google.com/task/13948555314372306568) started by @gokaiorg*