### PR TITLE
🎨 Palette: Replace text toggles with icons in LoginForm

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-07-04 - Replace Hardcoded Text Toggles with Standard Icons
+**Learning:** Hardcoding English text like "Show" or "Hide" in interactive toggles (like password visibility) inside components that accept translation dictionaries (e.g., `dict`) breaks internationalization. Replacing them with standard recognizable icons (like `Eye`/`EyeOff` from `lucide-react`) combined with `aria-hidden="true"` and an explicitly translated (or dynamic) `aria-label` on the parent interactive element provides a universally understood UX pattern that automatically bypasses the need for localizing the visible text itself.
+**Action:** When implementing or refactoring interactive toggles (like password visibility, mute, play/pause), prefer using universally recognizable icons over localized text to reduce internationalization overhead while ensuring the parent container retains an accessible, translatable `aria-label`.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,7 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? <EyeOff aria-hidden="true" className="h-4 w-4" /> : <Eye aria-hidden="true" className="h-4 w-4" />}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 **What**: Replaced the hardcoded "Show" and "Hide" text in the password visibility toggle of the `LoginForm` with the `Eye` and `EyeOff` icons from `lucide-react`.
🎯 **Why**: Using universally recognized visual icons makes the interface more intuitive and reduces the overhead of needing to provide translations for simple, common toggles (since the parent application supports multi-language capabilities via a `dict` prop).
📸 **Before/After**: Visually verified via Playwright screenshot generation (mocked UI) ensuring the icons fit and toggle cleanly within the existing input group.
♿ **Accessibility**: Applied `aria-hidden="true"` to the icons to prevent redundant screen reader announcements, relying entirely on the dynamic `aria-label` ("Show password" / "Hide password") defined on the parent `<Button>`.

---
*PR created automatically by Jules for task [8965890233801360586](https://jules.google.com/task/8965890233801360586) started by @gokaiorg*