### PR TITLE
⚡ Bolt: [deduplicate Firestore queries to halve database reads and improve TTFB]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-05-18 - [React.cache Deduplication]
+**Learning:** Next.js native `fetch` automatically deduplicates identical requests during the server rendering lifecycle, but SDK methods like `firebase-admin` do not. Missing deduplication can lead to duplicate database queries when the same data is needed in both `generateMetadata` and the page component itself, effectively doubling TTFB overhead and Firestore read costs.
+**Action:** Always wrap non-fetch database query functions with `React.cache()` to ensure they only execute once per request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { adminDb } from "@/lib/firebase-admin";
+import { cache } from "react";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
@@ -10,11 +11,13 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt: Use React.cache() to deduplicate Firestore queries between generateMetadata and the Page component.
+// This optimization halves the number of database reads per request, significantly improving server response time (TTFB).
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
 import { notFound } from "next/navigation";
@@ -11,10 +12,16 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// ⚡ Bolt: Use React.cache() to deduplicate Firestore queries between generateMetadata and the Page component.
+// This optimization halves the number of database reads per request, significantly improving server response time (TTFB).
+const getProductSnapshot = cache(async (slugField: string, slug: string) => {
+    return await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
### 💡 What:
Wrapped the Firestore queries for products and pages with `React.cache()` to ensure that the identical queries triggered by `generateMetadata` and the Page component share the same request-scoped cache.

### 🎯 Why:
In Next.js, while native `fetch` requests are automatically deduplicated during a single server-rendering pass, external SDK calls (like those from `firebase-admin`) are not. Because the same product or page document is fetched once to build metadata (title, description) and then again immediately to render the actual component, the server was executing two identical database reads per user request.

### 📊 Impact:
- **Halves database reads** per page load for the `/product/[slug]` and `/[slug]` routes.
- **Improves Time to First Byte (TTFB)** by eliminating redundant network latency to Firestore.
- Reduces Google Cloud/Firestore billing costs.

### 🔬 Measurement:
Start the local server and monitor the network/firestore logs for the `/product/test-product` route. Before this change, the `products` collection is queried twice per request. After this change, it is only queried once.

---
*PR created automatically by Jules for task [11844082715436693957](https://jules.google.com/task/11844082715436693957) started by @gokaiorg*