### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate Firestore queries with React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-05-24 - Firestore React.cache() Deduplication
+**Learning:** In Next.js App Router, while native `fetch()` calls are automatically memoized and deduplicated, direct database queries via the `firebase-admin` SDK are not. If the same query is executed in both `generateMetadata` and the default page component, it causes two redundant database hits per request. However, `React.cache()` handles serialization of primitive arguments (like strings) perfectly, and can successfully memoize the resulting `QuerySnapshot` Promise on the server.
+**Action:** When fetching data via `adminDb` in Next.js Server Components, especially when the same data is needed for metadata, wrap the query execution function in `React.cache()` to enforce single-execution per request lifecycle.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,16 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// ⚡ Bolt Performance Optimization
+// Why: In Next.js App Router, direct SDK database queries (like firebase-admin) executed in both
+// generateMetadata and the page component are not automatically deduplicated.
+// Wrapping the query in React.cache() prevents executing the exact same database query twice.
+// Impact: Eliminates redundant Firestore reads and reduces server-side response times.
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,25 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+// ⚡ Bolt Performance Optimization
+// Why: In Next.js App Router, fetch requests in both generateMetadata and the page component are automatically deduplicated.
+// However, direct SDK calls (like firebase-admin) are not. Wrapping the query in React.cache() ensures the database
+// is only hit once per request lifecycle, rather than twice.
+// Impact: Reduces Firestore reads by 50% for this route and significantly decreases TTFB.
+const getProductBySlug = cache(async (slugField: string, slug: string) => {
+    return adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +46,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 What: Wrapped direct `firebase-admin` Firestore queries in `src/app/[lang]/(shop)/product/[slug]/page.tsx` and `src/app/[lang]/(shop)/[slug]/page.tsx` with `React.cache()`.
🎯 Why: In Next.js App Router, while native `fetch` is automatically deduplicated, direct SDK calls are not. These routes were fetching the exact same data in both `generateMetadata` and the main component, causing redundant database reads and blocking the main thread twice.
📊 Impact: Reduces Firestore reads by exactly 50% for these routes per request, decreasing database costs and significantly improving Time to First Byte (TTFB).
🔬 Measurement: Verify by checking the server-side console logs or Firestore usage dashboard; each page load now generates one query instead of two.

---
*PR created automatically by Jules for task [9854127466622782110](https://jules.google.com/task/9854127466622782110) started by @gokaiorg*