### PR TITLE
🎨 Palette: Add Eye Icons to Password Toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## 2024-07-05 - Enhance Password Toggle with Lucide Icons
+**Learning:** Raw text like "Show" and "Hide" for password visibility toggles lacks visual polish and requires manual translation mapping, whereas standard icons are universally understood. Ensuring `aria-hidden="true"` on dynamic SVG icons prevents screen readers from redundantly announcing the visual icon along with the parent button's `aria-label`.
+**Action:** Always replace raw text on visibility toggles with standard `Eye`/`EyeOff` icons, ensuring they are hidden from screen readers to maintain clear and concise `aria-label` context.

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -133,7 +133,11 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 onClick={() => setShowPassword((prev) => !prev)}
                                 aria-label={showPassword ? "Hide password" : "Show password"}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff aria-hidden="true" className="h-4 w-4" />
+                                ) : (
+                                    <Eye aria-hidden="true" className="h-4 w-4" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:** 
Replaced the raw "Show" and "Hide" text in the `LoginForm`'s password visibility toggle with standard `Eye` and `EyeOff` icons from `lucide-react`.

**🎯 Why:** 
Raw text takes up more space, requires explicit localization mappings in dictionaries, and is less visually polished. Using widely recognized eye icons makes the interface more intuitive and universally understood at a glance.

**📸 Before/After:** 
Before: The button showed the literal words "Show" and "Hide".
After: The button cleanly displays an Eye icon, toggling to an EyeOff icon when the password is shown. 

**♿ Accessibility:** 
Maintained the existing explicit `aria-label` on the parent `<Button>` to accurately describe the toggle action. Added `aria-hidden="true"` to the new `<Eye>` and `<EyeOff>` SVG components to prevent screen readers from redundantly announcing the visual icon.

---
*PR created automatically by Jules for task [14320536113604349572](https://jules.google.com/task/14320536113604349572) started by @gokaiorg*