### PR TITLE
🎨 Palette: Add loading spinners to admin form submit buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## 2024-05-30 - Added Visual Loading States to Admin Forms
+**Learning:** Admin forms (`CategoryForm.tsx`, `PageForm.tsx`, `ProductForm.tsx`) were missing visual loading indicators on their submit buttons during `isPending` states, causing poor feedback during asynchronous operations.
+**Action:** Always add `<Loader2 className="mr-2 h-4 w-4 animate-spin" />` from `lucide-react` inside the submit button when `isPending` is true to provide immediate visual feedback.

--- a/src/components/admin/CategoryForm.tsx
+++ b/src/components/admin/CategoryForm.tsx
@@ -8,6 +8,7 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { createCategory, updateCategory } from "@/actions/admin";
 import { categorySchema } from "@/schemas/admin";
+import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -181,6 +182,7 @@ export function CategoryForm({ dict, lang, initialData }: { dict: Record<string,
                 </Accordion>
 
                 <Button type="submit" disabled={isPending}>
+                    {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isPending ? dict.submitting : dict.submit}
                 </Button>
             </form>

--- a/src/components/admin/PageForm.tsx
+++ b/src/components/admin/PageForm.tsx
@@ -8,6 +8,7 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { updatePage } from "@/actions/admin";
 import { pageSchema } from "@/schemas/admin";
+import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -179,6 +180,7 @@ export function PageForm({ dict, lang, initialData }: { dict: any; lang: string;
                 </Accordion>
 
                 <Button type="submit" disabled={isPending}>
+                    {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isPending ? dict.forms.submitting : dict.forms.submit}
                 </Button>
             </form>

--- a/src/components/admin/ProductForm.tsx
+++ b/src/components/admin/ProductForm.tsx
@@ -8,6 +8,7 @@ import * as z from "zod";
 import { toast } from "sonner";
 import { createProduct, updateProduct } from "@/actions/admin";
 import { productSchema } from "@/schemas/admin";
+import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -289,6 +290,7 @@ export function ProductForm({ categories, dict, lang, initialData }: { categorie
                 </div>
 
                 <Button type="submit" disabled={isPending}>
+                    {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isPending ? dict.submitting : dict.submit}
                 </Button>
             </form>


### PR DESCRIPTION
💡 **What**: Added visual loading spinners (`Loader2` from `lucide-react`) to the submit buttons in `CategoryForm`, `PageForm`, and `ProductForm`. The spinners are displayed when the form's `isPending` state is true.

🎯 **Why**: Previously, when an admin submitted a form, there was no immediate visual feedback that the async operation (saving to the database) was in progress, which could lead to confusion or double-clicks. This adds a standard, recognizable loading state.

📸 **Before/After**: 
- **Before**: Button text changes to "Submitting..." but lacks an icon.
- **After**: Button displays a spinning `Loader2` icon alongside the "Submitting..." text.

♿ **Accessibility**: Improves general usability by providing clear visual feedback that a system action is occurring, meeting the interaction improvement heuristic.

---
*PR created automatically by Jules for task [1162225077350137326](https://jules.google.com/task/1162225077350137326) started by @gokaiorg*