### PR TITLE
⚡ Bolt: Deduplicate redundant Firestore queries in dynamic pages using React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2025-04-06 - Deduplicating Firestore Queries in Next.js Server Components
+**Learning:** In Next.js App Router, functions like `generateMetadata` and the main page component often require the same data. While native `fetch` requests are automatically deduplicated by Next.js, direct database calls (such as Firebase Admin Firestore queries) are not. This causes the same query to execute multiple times per request, doubling database load and latency.
+**Action:** Always wrap non-fetch database query functions with `React.cache()` when they are used in both `generateMetadata` and the page component. This ensures the promise is memoized for the duration of the request lifecycle, completely eliminating redundant database operations.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { Metadata } from "next";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
@@ -11,10 +12,14 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
+const getProductSnapshot = cache(async (slugField: string, slug: string) => {
+    return adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+});
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
     
     if (snapshot.empty) {
         return {
@@ -36,7 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductSnapshot(slugField, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
⚡ What: Wrapped direct Firebase Admin queries (`adminDb.collection().get()`) inside `React.cache()` in dynamic page routes (`[slug]/page.tsx` and `product/[slug]/page.tsx`).

🎯 Why: In Next.js App Router, when `generateMetadata` and the default page component both fetch the exact same data, native `fetch` requests are automatically deduplicated. However, custom ORM or database SDK calls (like Firebase Admin) are *not* automatically deduplicated. This resulted in the same document being queried from Firestore twice during every server render. By wrapping these specific query functions in `React.cache()`, we memoize the returned Promise for the lifetime of the request.

📊 Impact: Cuts the number of Firestore database reads in half during SSR for the dynamic page and product page routes, halving the database overhead and significantly reducing Time to First Byte (TTFB).

🔬 Measurement: Verify by checking Next.js / Firebase debug logs during SSR for these routes before and after the change; there will now only be a single database query execution per route load.

---
*PR created automatically by Jules for task [7651059429481649711](https://jules.google.com/task/7651059429481649711) started by @gokaiorg*