### PR TITLE
⚡ Bolt: Deduplicate duplicate Firestore queries in dynamic pages using React.cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+## 2024-05-24 - Deduplicate App Router Queries with React.cache
+**Learning:** In Next.js App Router, direct database queries (like `firebase-admin` `get()` calls) executed in both `generateMetadata` and the main Page component are NOT automatically deduplicated like native `fetch()` calls. This results in the server running the identical query twice per request, wasting backend resources and slowing down SSR.
+**Action:** Always wrap these custom or non-fetch database query functions with `React.cache()`. Since Firestore `QuerySnapshot` promises returned by `adminDb.collection(...).get()` are serializable, they are perfectly cacheable by `React.cache()`, ensuring the query only executes once per server render lifecycle. Always include comments explaining this to future developers.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
@@ -10,11 +11,13 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+// Optimize duplicate queries: Cache the Firestore document read to prevent duplicate fetches
+// between generateMetadata and the DynamicPage component during SSR.
+const getPage = React.cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Metadata } from "next";
 import { adminDb } from "@/lib/firebase-admin";
 import { Product } from "@/types/database";
@@ -11,10 +12,17 @@ interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+// Optimize N+1 query: Cache the Firestore document read to prevent duplicate fetches
+// between generateMetadata and the Page component during SSR.
+const getProduct = React.cache(async (slug: string, lang: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const snapshot = await getProduct(slug, lang);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +43,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProduct(slug, lang);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
**💡 What:**
Wrapped custom Firestore database queries (`getProduct` and `getPage`) with `React.cache()` in dynamic product and custom page routes.

**🎯 Why:**
In Next.js App Router, functions like `generateMetadata` and the main Page component run sequentially on the server. Because the Firebase Admin SDK does not use the native `fetch` API under the hood, Next.js does not automatically deduplicate these identical network requests. Without `React.cache()`, identical Firestore queries were being executed twice per user request.

**📊 Impact:**
- Reduces database reads by exactly 50% for these routes (from 2 queries to 1 per request lifecycle).
- Reduces server CPU utilization.
- Faster server response times (SSR/TTFB) since the main component doesn't have to wait for the same database query to resolve a second time over the network.

**🔬 Measurement:**
- Check the Firebase console usage metrics or add temporary `console.log` statements inside the cached functions. The function will now only log once during the initial server render instead of twice.

---
*PR created automatically by Jules for task [14271803602670248017](https://jules.google.com/task/14271803602670248017) started by @gokaiorg*