### PR TITLE
🎨 Palette: [Add loading states to admin forms]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+## $(date +%Y-%m-%d) - Adding loading states to shadcn forms
+**Learning:** For forms wrapped in shadcn UI or simple Next.js forms, `isPending` state should always trigger a loading indicator to provide visual feedback during async actions. A pattern that works well without breaking layouts is adding `{isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}` inside the submit button.
+**Action:** When adding submit buttons to new forms, ensure they disable and show a `Loader2` or similar spinner alongside the submit text when the operation is pending.

--- a/src/components/admin/CategoryForm.tsx
+++ b/src/components/admin/CategoryForm.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
 import { createCategory, updateCategory } from "@/actions/admin";
 import { categorySchema } from "@/schemas/admin";
 
@@ -181,6 +182,7 @@ export function CategoryForm({ dict, lang, initialData }: { dict: Record<string,
                 </Accordion>
 
                 <Button type="submit" disabled={isPending}>
+                    {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isPending ? dict.submitting : dict.submit}
                 </Button>
             </form>

--- a/src/components/admin/PageForm.tsx
+++ b/src/components/admin/PageForm.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
 import { updatePage } from "@/actions/admin";
 import { pageSchema } from "@/schemas/admin";
 
@@ -179,6 +180,7 @@ export function PageForm({ dict, lang, initialData }: { dict: any; lang: string;
                 </Accordion>
 
                 <Button type="submit" disabled={isPending}>
+                    {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isPending ? dict.forms.submitting : dict.forms.submit}
                 </Button>
             </form>

--- a/src/components/admin/ProductForm.tsx
+++ b/src/components/admin/ProductForm.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
 import { createProduct, updateProduct } from "@/actions/admin";
 import { productSchema } from "@/schemas/admin";
 
@@ -289,6 +290,7 @@ export function ProductForm({ categories, dict, lang, initialData }: { categorie
                 </div>
 
                 <Button type="submit" disabled={isPending}>
+                    {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isPending ? dict.submitting : dict.submit}
                 </Button>
             </form>


### PR DESCRIPTION
💡 **What:** Added a loading spinner (`Loader2` from `lucide-react`) to the submit buttons on the `ProductForm`, `CategoryForm`, and `PageForm` in the admin dashboard. The spinner is displayed conditionally when the form is in an `isPending` state.
🎯 **Why:** To improve UX and accessibility by providing immediate visual feedback to the user when they submit a form, indicating that a background process is happening and the app is not frozen.
📸 **Before/After:** Before, the submit button would simply be disabled without visual change during submission. After, the button shows a spinning `Loader2` icon next to the "Submitting..." text.
♿ **Accessibility:** Provides clear visual status updates to users, reinforcing that an action has been registered and is processing. Disabled states prevent accidental double-submissions.

---
*PR created automatically by Jules for task [5864648164489688767](https://jules.google.com/task/5864648164489688767) started by @gokaiorg*