### PR TITLE
🎨 Palette: [UX improvement] Use icons for password visibility toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-04-28 - Accessible Skeletons vs Layout Shift
 **Learning:** Using a structurally equivalent disabled component (e.g., `<Button disabled>`) instead of a generic `<div className="animate-pulse w-16">` as an SSR/loading fallback for an icon button provides significantly better semantics for screen readers and avoids width-based Cumulative Layout Shift (CLS) in the header.
 **Action:** Default to using disabled variants of the actual interactive elements for loading skeletons rather than arbitrary div shapes.
+
+## $(date +%Y-%m-%d) - Password Visibility Toggle Icons and Localization
+**Learning:** Hardcoded "Show" or "Hide" text strings in password toggle buttons limit localization and clutter the UI. Relying solely on `aria-label` with decorative icons is standard practice, but the `aria-label` itself should also be dynamically translated using the `dict` dictionary, otherwise screen readers still read English to non-English users.
+**Action:** When converting text buttons to icon-only buttons (like password toggles using `Eye`/`EyeOff`), always ensure `aria-hidden="true"` is on the icon and the parent button's `aria-label` uses the translation dictionary (e.g., `dict.show_password || "Show password"`).

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loader2 } from "lucide-react";
+import { Loader2, Eye, EyeOff } from "lucide-react";
 import { registerUser } from "@/actions/auth";
 
 export function LoginForm({ dict }: { dict: Record<string, string> }) {
@@ -131,9 +131,13 @@ export function LoginForm({ dict }: { dict: Record<string, string> }) {
                                 size="sm"
                                 className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-muted-foreground hover:text-foreground"
                                 onClick={() => setShowPassword((prev) => !prev)}
-                                aria-label={showPassword ? "Hide password" : "Show password"}
+                                aria-label={showPassword ? (dict.hide_password || "Hide password") : (dict.show_password || "Show password")}
                             >
-                                {showPassword ? "Hide" : "Show"}
+                                {showPassword ? (
+                                    <EyeOff className="h-4 w-4" aria-hidden="true" />
+                                ) : (
+                                    <Eye className="h-4 w-4" aria-hidden="true" />
+                                )}
                             </Button>
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What:**
Replaced the hardcoded English text strings ("Show" / "Hide") with standard, recognizable icons (`Eye` / `EyeOff` from `lucide-react`) in the password visibility toggle of the `LoginForm` component.

**🎯 Why:**
Hardcoded text labels in UI interactive elements like password toggles increase visual clutter and complicate internationalization. Utilizing universally recognized icons provides a cleaner, more familiar user experience and removes hardcoded English strings from the interface.

**♿ Accessibility:**
The new icons are properly hidden from screen readers using `aria-hidden="true"`, preventing redundant or confusing announcements. The parent `<Button>` retains its explicit `aria-label`, which has now been updated to use the translation dictionary (`dict.hide_password` and `dict.show_password`) with safe English fallbacks, ensuring localized accessibility context for screen reader users.

---
*PR created automatically by Jules for task [12831430641119095528](https://jules.google.com/task/12831430641119095528) started by @gokaiorg*