### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in updateProfile server action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Empty string passwords were permitted in the type checking logic allowing authentication bypasses. The pass-the-hash check did not consider all common bcrypt prefixes.
 **Learning:** Checking for string types on passwords does not prevent empty strings. Additionally, pass-the-hash protection must cover all bcrypt formats ($2a$, $2b$, $2y$, $2x$).
 **Prevention:** Ensure explicit \`!credentials.password\` length checks exist, and explicitly verify user IDs are strings.
+## 2024-05-18 - Missing Authorization in Profile Update Server Action
+**Vulnerability:** Insecure Direct Object Reference (IDOR) in `updateProfile` where any user could update another user's profile by supplying their `uid`.
+**Learning:** Server Actions can bypass route-level middleware protection. They must explicitly implement session authorization checks directly within the action to prevent IDOR and authorization bypass vulnerabilities.
+**Prevention:** Always verify that the authenticated session ID (`session?.user?.id`) matches the target resource ID parameter to prevent IDOR, unless the user possesses an explicit admin role.

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { Role } from "@/types/database";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
+import { auth } from "@/auth";
 
 const registerSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
@@ -56,6 +57,11 @@ export async function registerUser(formData: FormData) {
 }
 
 export async function updateProfile(uid: string, data: { name?: string, email?: string, password?: string }) {
+    const session = await auth();
+    if (!session || !session.user || (session.user.id !== uid && session.user.role?.toLowerCase() !== "admin")) {
+        return { error: "Unauthorized" };
+    }
+
     const { adminAuth, adminDb } = await import("@/lib/firebase-admin");
 
     try {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `updateProfile` server action where any user could update another user's profile by supplying their `uid`. Route-level middleware protection (`middleware.ts`) does not secure server actions against direct invocation.
🎯 **Impact:** An attacker could exploit this to change the email, name, or password of any other user, leading to complete account takeover.
🔧 **Fix:** Added an explicit authorization check within the `updateProfile` server action. It retrieves the session using `await auth()` and verifies that the session belongs to the user being updated (`session.user.id === uid`) or that the user has an admin role. If not, it returns `{ error: "Unauthorized" }`.
✅ **Verification:** Ran `pnpm lint`, `pnpm build`, and `pnpm test` successfully. Verified the IDOR fix through code review. Code changes are under 50 lines. Documented the IDOR server action pattern in the Sentinel journal.

---
*PR created automatically by Jules for task [14380506918693937386](https://jules.google.com/task/14380506918693937386) started by @gokaiorg*