### PR TITLE
⚡ Bolt: Deduplicate metadata database queries with React.cache()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - [Plan Review Groundedness Rule]
 **Learning:** When using `cat` for large files, terminal output is easily truncated in the trace history. This leads to Groundedness Rule violations when proposing to remove variables or imports that are assumed to be unused.
 **Action:** Before proposing to remove any variables, imports, or code in an execution plan, explicitly verify they are genuinely unused in the entire file using targeted tools (like `grep -rn "variableName" file.tsx` or `read_file`) instead of relying solely on the potentially truncated output of `cat`.
+
+## 2024-05-25 - React.cache for deduplicating non-fetch queries
+**Learning:** In Next.js App Router, database calls (like `firebase-admin` SDK queries) inside `generateMetadata` and the page component execute twice per request because they are not automatically deduplicated like native `fetch`.
+**Action:** Always wrap non-fetch database query functions with `React.cache()` to ensure they only execute once per request lifecycle, reducing database reads and improving TTFB.

--- a/src/app/[lang]/(shop)/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { notFound } from "next/navigation";
 import parse from "html-react-parser";
 import { Metadata } from "next";
+import { cache } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -10,11 +11,11 @@ interface PageProps {
   }>;
 }
 
-async function getPage(slug: string) {
+const getPage = cache(async (slug: string) => {
   const doc = await adminDb.collection("pages").doc(slug).get();
   if (!doc.exists) return null;
   return doc.data();
-}
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { lang, slug } = await params;

--- a/src/app/[lang]/(shop)/product/[slug]/page.tsx
+++ b/src/app/[lang]/(shop)/product/[slug]/page.tsx
@@ -6,15 +6,21 @@ import Image from "next/image";
 import { getDictionary } from "@/lib/dictionaries";
 import { Locale } from "@/app/i18n-config";
 import { AddToCartButton } from "@/components/shop/AddToCartButton";
+import { cache } from "react";
 
 interface PageProps {
     params: Promise<{ lang: string; slug: string }>;
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const { lang, slug } = await params;
+const getProductBySlug = cache(async (lang: string, slug: string) => {
     const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
     const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    return snapshot;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { lang, slug } = await params;
+    const snapshot = await getProductBySlug(lang, slug);
     
     if (snapshot.empty) {
         return {
@@ -35,8 +41,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function ProductPage({ params }: PageProps) {
     const { lang, slug } = await params;
-    const slugField = lang === 'fr' ? 'slugFr' : 'slugEn';
-    const snapshot = await adminDb.collection("products").where(slugField, "==", slug).limit(1).get();
+    const snapshot = await getProductBySlug(lang, slug);
 
     if (snapshot.empty) {
         notFound();


### PR DESCRIPTION
💡 **What:** 
Wrapped the direct Firestore queries (`firebase-admin` SDK calls) inside `src/app/[lang]/(shop)/[slug]/page.tsx` and `src/app/[lang]/(shop)/product/[slug]/page.tsx` using `React.cache()`. Extracted the inline query in the product route into a dedicated `getProductBySlug` helper to facilitate this.

🎯 **Why:** 
In Next.js App Router, while native `fetch` requests are automatically deduplicated during the request lifecycle, third-party database clients (like the Firebase Admin SDK) are not. Because both `generateMetadata` and the default page component execute independently on the server, the identical Firestore queries were being executed twice per page load. This resulted in redundant database reads and a slower Time to First Byte (TTFB).

📊 **Impact:** 
- Cuts database reads per page visit for these routes by exactly 50%.
- Noticeably improves SSR response times (TTFB) by eliminating the duplicate network roundtrip to Firestore.

🔬 **Measurement:**
- Verified by checking that `pnpm build` completes successfully.
- Code review passed.
- At runtime, monitoring Firebase console read operations will show 1 read per page load instead of 2.

---
*PR created automatically by Jules for task [8483329029988566344](https://jules.google.com/task/8483329029988566344) started by @gokaiorg*